### PR TITLE
Fix typos

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -108,7 +108,7 @@ You can report issues to the fastplotlib core team:
 [Caitlin Lewis](https://github.com/clewis7)
 
 If your report involves any members of the fastplotlib core team, or if they feel they have
-a conflict of interest in handling it, then they will recuse themselves from
+a conflict of interest in handling it, then they will recurse themselves from
 considering your report.
 
 # Incident reporting resolution & Code of Conduct enforcement

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -108,7 +108,7 @@ You can report issues to the fastplotlib core team:
 [Caitlin Lewis](https://github.com/clewis7)
 
 If your report involves any members of the fastplotlib core team, or if they feel they have
-a conflict of interest in handling it, then they will recurse themselves from
+a conflict of interest in handling it, then they will recuse themselves from
 considering your report.
 
 # Incident reporting resolution & Code of Conduct enforcement

--- a/docs/source/quickstart.ipynb
+++ b/docs/source/quickstart.ipynb
@@ -599,7 +599,7 @@
     "plot_v.add_image(data=data, name=\"random-image\")\n",
     "\n",
     "# a function to update the image_graphic\n",
-    "# a plot will pass its plot instance to the animation function as an arugment\n",
+    "# a plot will pass its plot instance to the animation function as an argument\n",
     "def update_data(plot_instance):\n",
     "    new_data = np.random.rand(512, 512)\n",
     "    plot_instance[\"random-image\"].data = new_data\n",
@@ -1073,7 +1073,7 @@
     "\n",
     "plot_l.add_image(img, name=\"image\", cmap=\"gray\")\n",
     "\n",
-    "# z axix position -1 so it is below all the lines\n",
+    "# z axis position -1 so it is below all the lines\n",
     "plot_l[\"image\"].position_z = -1\n",
     "plot_l[\"image\"].position_x = -50"
    ]

--- a/examples/notebooks/simple.ipynb
+++ b/examples/notebooks/simple.ipynb
@@ -533,7 +533,7 @@
     "plot_v.add_image(data=data, name=\"random-image\")\n",
     "\n",
     "# a function to update the image_graphic\n",
-    "# a plot will pass its plot instance to the animation function as an arugment\n",
+    "# a plot will pass its plot instance to the animation function as an argument\n",
     "def update_data(plot_instance):\n",
     "    new_data = np.random.rand(512, 512)\n",
     "    plot_instance[\"random-image\"].data = new_data\n",
@@ -952,7 +952,7 @@
     "\n",
     "plot_l.add_image(img[::20, ::20], name=\"image\", cmap=\"gray\")\n",
     "\n",
-    "# z axix position -1 so it is below all the lines\n",
+    "# z axis position -1 so it is below all the lines\n",
     "plot_l[\"image\"].position_z = -1\n",
     "plot_l[\"image\"].position_x = -8\n",
     "plot_l[\"image\"].position_y = -8"

--- a/fastplotlib/graphics/_features/_present.py
+++ b/fastplotlib/graphics/_features/_present.py
@@ -38,7 +38,7 @@ class PresentFeature(GraphicFeature):
 
             if i > 100:
                 raise RecursionError(
-                    "Exceded scene graph depth threshold, cannot find Scene associated with"
+                    "Exceeded scene graph depth threshold, cannot find Scene associated with"
                     "this graphic."
                 )
 

--- a/fastplotlib/graphics/selectors/_sync.py
+++ b/fastplotlib/graphics/selectors/_sync.py
@@ -74,7 +74,7 @@ class Synchronizer:
         for s in self.selectors:
             # must use == and not is to compare Graphics because they are weakref proxies!
             if s == source:
-                # if it's the source, since it has already movied
+                # if it's the source, since it has already moved
                 continue
 
             s._move_graphic(delta)

--- a/fastplotlib/layouts/_base.py
+++ b/fastplotlib/layouts/_base.py
@@ -40,7 +40,7 @@ class PlotArea:
     ):
         """
         Base class for plot creation and management. ``PlotArea`` is not intended to be instantiated by users
-        but rather to provide functionallity for ``subplot`` in ``gridplot`` and single ``plot``.
+        but rather to provide functionality for ``subplot`` in ``gridplot`` and single ``plot``.
 
         Parameters
         ----------

--- a/fastplotlib/widgets/image.py
+++ b/fastplotlib/widgets/image.py
@@ -300,7 +300,7 @@ class ImageWidget:
                 if names is not None:
                     if not all([isinstance(n, str) for n in names]):
                         raise TypeError(
-                            "optinal argument `names` must be a list of str"
+                            "optional argument `names` must be a list of str"
                         )
 
                     if len(names) != len(self.data):
@@ -350,7 +350,7 @@ class ImageWidget:
                 # dict of {array_ix: dims_order_str}
                 for data_ix in list(dims_order.keys()):
                     if not isinstance(data_ix, int):
-                        raise TypeError("`dims_oder` dict keys must be <int>")
+                        raise TypeError("`dims_order` dict keys must be <int>")
                     if len(dims_order[data_ix]) != self.ndim:
                         raise ValueError(
                             f"number of dims '{len(dims_order)} passed to `dims_order` "


### PR DESCRIPTION
Found via `codespell -L nwo,fo,te,ue,nd,ned,noo,bumb,bu,tbe,morg`