### PR TITLE
add desktop-only CI, add py312, remove `ipywidgets` import in `plot.py`, pin `pygfx>=0.1.14`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install llvmpipe and lavapipe for offscreen canvas, and git lfs
       run: |
         sudo apt-get update -y -qq
@@ -36,7 +36,7 @@ jobs:
         sudo apt-get install ./pandoc-3.1.4-1-amd64.deb
     - name: Install dev dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         # remove pygfx from install_requires, we install using pygfx@main
         sed -i "/pygfx/d" ./setup.py
         pip install git+https://github.com/pygfx/pygfx.git@main
@@ -77,7 +77,7 @@ jobs:
         sudo apt-get install --no-install-recommends -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
     - name: Install dev dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         # remove pygfx from install_requires, we install using pygfx@main
         sed -i "/pygfx/d" ./setup.py
         pip install git+https://github.com/pygfx/pygfx.git@main
@@ -134,7 +134,7 @@ jobs:
         sudo apt-get install --no-install-recommends -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
     - name: Install dev dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         # remove pygfx from install_requires, we install using pygfx@main
         sed -i "/pygfx/d" ./setup.py
         pip install git+https://github.com/pygfx/pygfx.git@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip
-        # remove pygfx from requirements, we install a specific commit of pygfx since both fpl and pygfx are fast evolving
+        # remove pygfx from install_requires, we install using pygfx@main
         sed -i "/pygfx/d" ./setup.py
         pip install git+https://github.com/pygfx/pygfx.git@main
         pip install -e ".[notebook,docs,tests]"
@@ -46,8 +46,8 @@ jobs:
         cd docs
         make html SPHINXOPTS="-W --keep-going"
 
-  test-build:
-    name: Test examples
+  test-build-full:
+    name: Test examples, env with notebook and glfw
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     strategy:
@@ -60,6 +60,8 @@ jobs:
             pyversion: '3.10'
           - name: Test py311
             pyversion: '3.11'
+          - name: Test py312
+            pyversion: '3.12'
     steps:
     - name: Install git-lfs
       run: |
@@ -76,7 +78,7 @@ jobs:
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip
-        # remove pygfx from requirements, we install a specific commit of pygfx since both fpl and pygfx are fast evolving
+        # remove pygfx from install_requires, we install using pygfx@main
         sed -i "/pygfx/d" ./setup.py
         pip install git+https://github.com/pygfx/pygfx.git@main
         pip install -e ".["tests"]"
@@ -100,3 +102,59 @@ jobs:
         path: |
           examples/desktop/diffs
           examples/notebooks/diffs
+
+  test-build-desktop:
+    name: Test examples, env with only glfw
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Test py39
+            pyversion: '3.9'
+          - name: Test py310
+            pyversion: '3.10'
+          - name: Test py311
+            pyversion: '3.11'
+          - name: Test py312
+            pyversion: '3.12'
+    steps:
+    - name: Install git-lfs
+      run: |
+        sudo apt install --no-install-recommends -y  git-lfs
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.pyversion }}
+    - name: Install llvmpipe and lavapipe for offscreen canvas
+      run: |
+        sudo apt-get update -y -qq
+        sudo apt-get install --no-install-recommends -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
+    - name: Install dev dependencies
+      run: |
+        python -m pip install --upgrade pip
+        # remove pygfx from install_requires, we install using pygfx@main
+        sed -i "/pygfx/d" ./setup.py
+        pip install git+https://github.com/pygfx/pygfx.git@main
+        pip install glfw
+        pip install -e .
+    - name: Show wgpu backend
+      run:
+        python -c "from examples.tests.testutils import wgpu_backend; print(wgpu_backend)"
+    - name: fetch git lfs files
+      run: |
+        git lfs fetch --all
+        git lfs pull
+    - name: Test examples
+      env:
+        PYGFX_EXPECT_LAVAPIPE: true
+      run: |
+        pytest -v examples
+    - uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: screenshot-diffs
+        path: |
+          examples/desktop/diffs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,7 @@ jobs:
         # remove pygfx from install_requires, we install using pygfx@main
         sed -i "/pygfx/d" ./setup.py
         pip install git+https://github.com/pygfx/pygfx.git@main
-        pip install glfw
-        pip install -e .
+        pip install -e ".["tests-desktop"]"
     - name: Show wgpu backend
       run:
         python -c "from examples.tests.testutils import wgpu_backend; print(wgpu_backend)"

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.x'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dev dependencies
         run: |
           python -m pip install --upgrade pip
-          # remove pygfx from requirements, we install a specific commit of pygfx since both fpl and pygfx are fast evolving
+          # remove pygfx from install_requires, we install using pygfx@main
           sed -i "/pygfx/d" ./setup.py
           pip install git+https://github.com/pygfx/pygfx.git@main
           pip install -e ".["tests"]"

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -20,17 +20,17 @@ jobs:
         run: |
           sudo apt install --no-install-recommends -y  git-lfs
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install llvmpipe and lavapipe for offscreen canvas
         run: |
           sudo apt-get update -y -qq
           sudo apt-get install --no-install-recommends -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
       - name: Install dev dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           # remove pygfx from install_requires, we install using pygfx@main
           sed -i "/pygfx/d" ./setup.py
           pip install git+https://github.com/pygfx/pygfx.git@main

--- a/fastplotlib/layouts/_plot.py
+++ b/fastplotlib/layouts/_plot.py
@@ -3,7 +3,6 @@ from datetime import datetime
 import traceback
 import os
 
-import ipywidgets
 import pygfx
 from wgpu.gui.auto import WgpuCanvas, is_jupyter
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,15 @@ extras_require = {
         "scikit-learn",
         "tqdm",
         "sidecar"
+    ],
+
+    "tests-desktop":
+    [
+        "pytest",
+        "scipy",
+        "imageio",
+        "scikit-learn",
+        "tqdm",
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 install_requires = [
     "numpy>=1.23.0",
-    "pygfx>=0.1.13",
+    "pygfx>=0.1.14",
 ]
 
 


### PR DESCRIPTION
1. This adds CI to test that the examples work in an environment without jupyter and ipywidgets, to make sure that the examples work in a "minimal" env with only glfw.
2. Add python 3.12 to CI
3. remove `ipywidgets` import from `layouters/_plot.py`
4. pin `pygfx>=0.1.14`
