### PR TITLE
Fix selector garbage collection

### DIFF
--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -158,6 +158,15 @@ class Graphic(BaseGraphic):
 
         return False
 
+    def _cleanup(self):
+        """
+        Cleans up the graphic in preparation for __del__(), such as removing event handlers from
+        plot renderer, feature event handlers, etc.
+
+        Optionally implemented in subclasses
+        """
+        pass
+
     def __del__(self):
         del WORLD_OBJECTS[self.loc]
 

--- a/fastplotlib/graphics/image.py
+++ b/fastplotlib/graphics/image.py
@@ -149,7 +149,7 @@ class _AddSelectorsMixin:
         if axis == "x":
             offset = self.position_x
             # x limits, number of columns
-            limits = (offset, data.shape[1])
+            limits = (offset, data.shape[1] - 1)
 
             # size is number of rows + padding
             # used by LinearRegionSelector but not LinearSelector
@@ -169,7 +169,7 @@ class _AddSelectorsMixin:
         else:
             offset = self.position_y
             # y limits
-            limits = (offset, data.shape[0])
+            limits = (offset, data.shape[0] - 1)
 
             # width + padding
             # used by LinearRegionSelector but not LinearSelector

--- a/fastplotlib/graphics/selectors/_linear_region.py
+++ b/fastplotlib/graphics/selectors/_linear_region.py
@@ -17,7 +17,7 @@ from ._base_selector import BaseSelector
 from .._features._selection_features import LinearRegionSelectionFeature
 
 
-class LinearRegionSelector(Graphic, BaseSelector):
+class LinearRegionSelector(BaseSelector):
     @property
     def limits(self) -> Tuple[float, float]:
         return self._limits
@@ -126,8 +126,6 @@ class LinearRegionSelector(Graphic, BaseSelector):
         #             f"limits[0] != position[1] != bounds[0]\n"
         #             f"{limits[0]} != {origin[1]} != {bounds[0]}"
         #         )
-
-        Graphic.__init__(self, name=name)
 
         self.parent = parent
 
@@ -241,6 +239,7 @@ class LinearRegionSelector(Graphic, BaseSelector):
             hover_responsive=self.edges,
             arrow_keys_modifier=arrow_keys_modifier,
             axis=axis,
+            name=name
         )
 
     def get_selected_data(

--- a/fastplotlib/graphics/selectors/_polygon.py
+++ b/fastplotlib/graphics/selectors/_polygon.py
@@ -8,7 +8,7 @@ from ._base_selector import BaseSelector, MoveInfo
 from .._base import Graphic
 
 
-class PolygonSelector(Graphic, BaseSelector):
+class PolygonSelector(BaseSelector):
     def __init__(
         self,
         edge_color="magenta",
@@ -16,7 +16,6 @@ class PolygonSelector(Graphic, BaseSelector):
         parent: Graphic = None,
         name: str = None,
     ):
-        Graphic.__init__(self, name=name)
 
         self.parent = parent
 
@@ -30,6 +29,8 @@ class PolygonSelector(Graphic, BaseSelector):
         self._move_info: MoveInfo = None
 
         self._current_mode = None
+
+        BaseSelector.__init__(self, name=name)
 
     def get_vertices(self) -> np.ndarray:
         """Get the vertices for the polygon"""

--- a/fastplotlib/graphics/selectors/_sync.py
+++ b/fastplotlib/graphics/selectors/_sync.py
@@ -39,8 +39,12 @@ class Synchronizer:
 
     def remove(self, selector):
         """remove a selector"""
-        self._selectors.remove(selector)
         selector.selection.remove_event_handler(self._handle_event)
+        self._selectors.remove(selector)
+
+    def clear(self):
+        for i in range(len(self.selectors)):
+            self.remove(self.selectors[0])
 
     def _handle_event(self, ev):
         if self.block_event:
@@ -81,7 +85,4 @@ class Synchronizer:
             s._move_graphic(delta)
 
     def __del__(self):
-        for s in self.selectors:
-            self.remove(s)
-
-        self.selectors.clear()
+        self.clear()

--- a/fastplotlib/layouts/_base.py
+++ b/fastplotlib/layouts/_base.py
@@ -329,12 +329,16 @@ class PlotArea:
             else:
                 self._graphics.append(loc)
 
+        # now that it's in the dict, just use the weakref
+        graphic = weakref.proxy(graphic)
+
         # add world object to scene
         self.scene.add(graphic.world_object)
 
         if center:
             self.center_graphic(graphic)
 
+        # if we don't use the weakref above, then the object lingers if a plot hook is used!
         if hasattr(graphic, "_add_plot_area_hook"):
             graphic._add_plot_area_hook(self)
 
@@ -482,6 +486,9 @@ class PlotArea:
 
         # remove from list of addresses
         glist.remove(loc)
+
+        # cleanup
+        graphic._cleanup()
 
         if kind == "graphic":
             del GRAPHICS[loc]

--- a/fastplotlib/layouts/_base.py
+++ b/fastplotlib/layouts/_base.py
@@ -420,6 +420,12 @@ class PlotArea:
         else:
             width, height, depth = (1, 1, 1)
 
+        # make sure width and height are non-zero
+        if width < 0.01:
+            width = 1
+        if height < 0.01:
+            height = 1
+
         for selector in self.selectors:
             self.scene.add(selector.world_object)
 


### PR DESCRIPTION
WIP

Still have some issues in the context of mesviz when switching CNMF items:

```python
Exception ignored in: <function Synchronizer.__del__ at 0x7f515504dd00>
Traceback (most recent call last):
  File "/home/kushal/repos/fastplotlib/fastplotlib/graphics/selectors/_sync.py", line 85, in __del__
    self.remove(s)
  File "/home/kushal/repos/fastplotlib/fastplotlib/graphics/selectors/_sync.py", line 43, in remove
    selector.selection.remove_event_handler(self._handle_event)
    ^^^^^^^^^^^^^^^^^^
ReferenceError: weakly-referenced object no longer exists
/home/kushal/repos/mesmerize-viz/mesmerize_viz/_cnmf/_viz_container.py:275: FutureWarning: You are trying to use the following experimental feature, this may change in the future without warning:
CaimanDataFrameExtensions.get_params_diffs
This feature is new and the might improve in the future

  param_diffs = self._dataframe.caiman.get_params_diffs(
10:16:55 PM
---------------------------------------------------------------------------
RecursionError                            Traceback (most recent call last)
File ~/venvs/mescore/lib/python3.11/site-packages/ipywidgets/widgets/widget.py:773, in Widget._handle_msg(self, msg)
    771         if 'buffer_paths' in data:
    772             _put_buffers(state, data['buffer_paths'], msg['buffers'])
--> 773         self.set_state(state)
    775 # Handle a state request.
    776 elif method == 'request_state':

File ~/venvs/mescore/lib/python3.11/site-packages/ipywidgets/widgets/widget.py:650, in Widget.set_state(self, sync_data)
    645         self._send(msg, buffers=echo_buffers)
    647 # The order of these context managers is important. Properties must
    648 # be locked when the hold_trait_notification context manager is
    649 # released and notifications are fired.
--> 650 with self._lock_property(**sync_data), self.hold_trait_notifications():
    651     for name in sync_data:
    652         if name in self.keys:

File /usr/lib/python3.11/contextlib.py:144, in _GeneratorContextManager.__exit__(self, typ, value, traceback)
    142 if typ is None:
    143     try:
--> 144         next(self.gen)
    145     except StopIteration:
    146         return False

File ~/venvs/mescore/lib/python3.11/site-packages/traitlets/traitlets.py:1524, in HasTraits.hold_trait_notifications(self)
   1522 for changes in cache.values():
   1523     for change in changes:
-> 1524         self.notify_change(change)

File ~/venvs/mescore/lib/python3.11/site-packages/ipywidgets/widgets/widget.py:701, in Widget.notify_change(self, change)
    698     if name in self.keys and self._should_send_property(name, getattr(self, name)):
    699         # Send new state to front-end
    700         self.send_state(key=name)
--> 701 super().notify_change(change)

File ~/venvs/mescore/lib/python3.11/site-packages/traitlets/traitlets.py:1539, in HasTraits.notify_change(self, change)
   1537 def notify_change(self, change):
   1538     """Notify observers of a change event"""
-> 1539     return self._notify_observers(change)

File ~/venvs/mescore/lib/python3.11/site-packages/traitlets/traitlets.py:1586, in HasTraits._notify_observers(self, event)
   1583 elif isinstance(c, EventHandler) and c.name is not None:
   1584     c = getattr(self, c.name)
-> 1586 c(event)

File ~/repos/mesmerize-viz/mesmerize_viz/_cnmf/_wrapper.py:231, in GridPlotWrapper.__init__.<locals>.<lambda>(change)
    227 for trait in ["value", "max"]:
    228     jslink((self.component_slider, trait), (self.component_int_box, trait))
    230 self.component_int_box.observe(
--> 231     lambda change: self.set_component_index(change["new"]), "value"
    232 )
    234 # gridplot for each sublist
    235 for sub_data in self._data:

File ~/repos/mesmerize-viz/mesmerize_viz/_cnmf/_wrapper.py:277, in GridPlotWrapper.set_component_index(self, index)
    274 for s in self.heatmap_selectors:
    275     # TODO: Very hacky for now, ignores if the slider is currently being moved, prevents weird slider movement
    276     if s._move_info is None:
--> 277         s.selection = index
    279 self.component_int_box.value = index

File ~/repos/fastplotlib/fastplotlib/graphics/_base.py:139, in Graphic.__setattr__(self, key, value)
    137     attr = getattr(self, key)
    138     if isinstance(attr, GraphicFeature):
--> 139         attr._set(value)
    140         return
    142 super().__setattr__(key, value)

File ~/repos/fastplotlib/fastplotlib/graphics/_features/_selection_features.py:166, in LinearSelectionFeature._set(self, value)
    163     self._parent.position_y = value
    165 self._data = value
--> 166 self._feature_changed(key=None, new_data=value)

File ~/repos/fastplotlib/fastplotlib/graphics/_features/_selection_features.py:192, in LinearSelectionFeature._feature_changed(self, key, new_data)
    181 pick_info = {
    182     "world_object": self._parent.world_object,
    183     "new_data": new_data,
   (...)
    187     "delta": self._parent.delta,
    188 }
    190 event_data = FeatureEvent(type="selection", pick_info=pick_info)
--> 192 self._call_event_handlers(event_data)

File ~/repos/fastplotlib/fastplotlib/graphics/_features/_base.py:185, in GraphicFeature._call_event_handlers(self, event_data)
    183         func()
    184     else:
--> 185         func(event_data)
    186 else:
    187     func()

File ~/repos/mesmerize-viz/mesmerize_viz/_cnmf/_wrapper.py:284, in GridPlotWrapper._heatmap_set_component_index(self, ev)
    281 def _heatmap_set_component_index(self, ev):
    282     index = ev.pick_info["selected_index"]
--> 284     self.set_component_index(index)

File ~/repos/mesmerize-viz/mesmerize_viz/_cnmf/_wrapper.py:277, in GridPlotWrapper.set_component_index(self, index)
    274 for s in self.heatmap_selectors:
    275     # TODO: Very hacky for now, ignores if the slider is currently being moved, prevents weird slider movement
    276     if s._move_info is None:
--> 277         s.selection = index
    279 self.component_int_box.value = index

File ~/repos/fastplotlib/fastplotlib/graphics/_base.py:139, in Graphic.__setattr__(self, key, value)
    137     attr = getattr(self, key)
    138     if isinstance(attr, GraphicFeature):
--> 139         attr._set(value)
    140         return
    142 super().__setattr__(key, value)

File ~/repos/fastplotlib/fastplotlib/graphics/_features/_selection_features.py:166, in LinearSelectionFeature._set(self, value)
    163     self._parent.position_y = value
    165 self._data = value
--> 166 self._feature_changed(key=None, new_data=value)

File ~/repos/fastplotlib/fastplotlib/graphics/_features/_selection_features.py:192, in LinearSelectionFeature._feature_changed(self, key, new_data)
    181 pick_info = {
    182     "world_object": self._parent.world_object,
    183     "new_data": new_data,
   (...)
    187     "delta": self._parent.delta,
    188 }
    190 event_data = FeatureEvent(type="selection", pick_info=pick_info)
--> 192 self._call_event_handlers(event_data)

File ~/repos/fastplotlib/fastplotlib/graphics/_features/_base.py:185, in GraphicFeature._call_event_handlers(self, event_data)
    183         func()
    184     else:
--> 185         func(event_data)
    186 else:
    187     func()

File ~/repos/mesmerize-viz/mesmerize_viz/_cnmf/_wrapper.py:284, in GridPlotWrapper._heatmap_set_component_index(self, ev)
    281 def _heatmap_set_component_index(self, ev):
    282     index = ev.pick_info["selected_index"]
--> 284     self.set_component_index(index)

    [... skipping similar frames: Graphic.__setattr__ at line 139 (489 times), GridPlotWrapper.set_component_index at line 277 (489 times), GraphicFeature._call_event_handlers at line 185 (488 times), LinearSelectionFeature._feature_changed at line 192 (488 times), GridPlotWrapper._heatmap_set_component_index at line 284 (488 times), LinearSelectionFeature._set at line 166 (488 times)]

File ~/repos/fastplotlib/fastplotlib/graphics/_features/_selection_features.py:166, in LinearSelectionFeature._set(self, value)
    163     self._parent.position_y = value
    165 self._data = value
--> 166 self._feature_changed(key=None, new_data=value)

File ~/repos/fastplotlib/fastplotlib/graphics/_features/_selection_features.py:192, in LinearSelectionFeature._feature_changed(self, key, new_data)
    181 pick_info = {
    182     "world_object": self._parent.world_object,
    183     "new_data": new_data,
   (...)
    187     "delta": self._parent.delta,
    188 }
    190 event_data = FeatureEvent(type="selection", pick_info=pick_info)
--> 192 self._call_event_handlers(event_data)

File ~/repos/fastplotlib/fastplotlib/graphics/_features/_base.py:185, in GraphicFeature._call_event_handlers(self, event_data)
    183         func()
    184     else:
--> 185         func(event_data)
    186 else:
    187     func()

File ~/repos/mesmerize-viz/mesmerize_viz/_cnmf/_wrapper.py:284, in GridPlotWrapper._heatmap_set_component_index(self, ev)
    281 def _heatmap_set_component_index(self, ev):
    282     index = ev.pick_info["selected_index"]
--> 284     self.set_component_index(index)

File ~/repos/mesmerize-viz/mesmerize_viz/_cnmf/_wrapper.py:277, in GridPlotWrapper.set_component_index(self, index)
    274 for s in self.heatmap_selectors:
    275     # TODO: Very hacky for now, ignores if the slider is currently being moved, prevents weird slider movement
    276     if s._move_info is None:
--> 277         s.selection = index
    279 self.component_int_box.value = index

File ~/repos/fastplotlib/fastplotlib/graphics/_base.py:139, in Graphic.__setattr__(self, key, value)
    137     attr = getattr(self, key)
    138     if isinstance(attr, GraphicFeature):
--> 139         attr._set(value)
    140         return
    142 super().__setattr__(key, value)

File ~/repos/fastplotlib/fastplotlib/graphics/_features/_selection_features.py:163, in LinearSelectionFeature._set(self, value)
    161     self._parent.position_x = value
    162 else:
--> 163     self._parent.position_y = value
    165 self._data = value
    166 self._feature_changed(key=None, new_data=value)

File ~/repos/fastplotlib/fastplotlib/graphics/_base.py:142, in Graphic.__setattr__(self, key, value)
    139         attr._set(value)
    140         return
--> 142 super().__setattr__(key, value)

File ~/repos/fastplotlib/fastplotlib/graphics/_base.py:114, in Graphic.position_y(self, val)
    112 @position_y.setter
    113 def position_y(self, val):
--> 114     self.world_object.world.y = val

File ~/repos/pygfx/pygfx/utils/transform.py:381, in AffineBase.y(self, value)
    378 @y.setter
    379 def y(self, value):
    380     x, _, z = self.position
--> 381     self.position = (x, value, z)

File ~/repos/pygfx/pygfx/utils/transform.py:336, in AffineBase.position(self, value)
    334 @position.setter
    335 def position(self, value):
--> 336     self.matrix = la.mat_compose(value, self.rotation, self.scale)

File ~/repos/pygfx/pygfx/utils/transform.py:720, in RecursiveTransform.matrix(self, value)
    718 @matrix.setter
    719 def matrix(self, value):
--> 720     self.own.matrix = self._parent.inverse_matrix @ value

File ~/repos/pygfx/pygfx/utils/transform.py:553, in AffineTransform.matrix(self, value)
    550 @matrix.setter
    551 def matrix(self, value):
    552     self.untracked_matrix[:] = value
--> 553     self.flag_update()

File ~/repos/pygfx/pygfx/utils/transform.py:542, in AffineTransform.flag_update(self)
    540 def flag_update(self):
    541     self.last_modified = perf_counter_ns()
--> 542     super().flag_update()

File ~/repos/pygfx/pygfx/utils/transform.py:193, in AffineBase.flag_update(self)
    191 """Signal that this transform has updated."""
    192 for callback in list(self.update_callbacks.values()):
--> 193     callback(self)

File ~/repos/pygfx/pygfx/utils/transform.py:73, in callback.__get__.<locals>.inner(*args, **kwargs)
     70 if weak_instance() is None:
     71     return
---> 73 return self.callback_fn(weak_instance(), *args, **kwargs)

File ~/repos/pygfx/pygfx/utils/transform.py:684, in RecursiveTransform._own_updated(self, own)
    682 origin = self.parent.position
    683 self._reference_up = la.vec_normalize(new_ref - origin)
--> 684 self.flag_update()

File ~/repos/pygfx/pygfx/utils/transform.py:667, in RecursiveTransform.flag_update(self)
    665 def flag_update(self):
    666     self.last_modified = perf_counter_ns()
--> 667     super().flag_update()

File ~/repos/pygfx/pygfx/utils/transform.py:193, in AffineBase.flag_update(self)
    191 """Signal that this transform has updated."""
    192 for callback in list(self.update_callbacks.values()):
--> 193     callback(self)

File ~/repos/pygfx/pygfx/utils/transform.py:73, in callback.__get__.<locals>.inner(*args, **kwargs)
     70 if weak_instance() is None:
     71     return
---> 73 return self.callback_fn(weak_instance(), *args, **kwargs)

File ~/repos/pygfx/pygfx/utils/transform.py:672, in RecursiveTransform._parent_updated(self, parent)
    669 @callback
    670 def _parent_updated(self, parent: AffineBase):
    671     self._propagate_reference_up()
--> 672     self.flag_update()

File ~/repos/pygfx/pygfx/utils/transform.py:667, in RecursiveTransform.flag_update(self)
    665 def flag_update(self):
    666     self.last_modified = perf_counter_ns()
--> 667     super().flag_update()

File ~/repos/pygfx/pygfx/utils/transform.py:193, in AffineBase.flag_update(self)
    191 """Signal that this transform has updated."""
    192 for callback in list(self.update_callbacks.values()):
--> 193     callback(self)

File ~/repos/pygfx/pygfx/utils/transform.py:73, in callback.__get__.<locals>.inner(*args, **kwargs)
     70 if weak_instance() is None:
     71     return
---> 73 return self.callback_fn(weak_instance(), *args, **kwargs)

File ~/repos/pygfx/pygfx/objects/_base.py:186, in WorldObject._update_uniform_buffers(self, transform)
    184 self.uniform_buffer.data["world_transform"] = transform.matrix.T
    185 self.uniform_buffer.data["world_transform_inv"] = transform.inverse_matrix.T
--> 186 self.uniform_buffer.update_range()

File ~/repos/pygfx/pygfx/resources/_buffer.py:199, in Buffer.update_range(self, offset, size)
    197 Resource._rev += 1
    198 self._rev = Resource._rev
--> 199 self._gfx_mark_for_sync()

File ~/repos/pygfx/pygfx/resources/_base.py:74, in Resource._gfx_mark_for_sync(self)
     73 def _gfx_mark_for_sync(self):
---> 74     resource_update_registry._gfx_mark_for_sync(self)

File ~/repos/pygfx/pygfx/resources/_base.py:96, in ResourceUpdateRegistry._gfx_mark_for_sync(self, resource)
     94     raise TypeError("Given object is not a Resource")
     95 if resource._wgpu_object is not None and resource._gfx_pending_uploads:
---> 96     self._syncable.add(resource)

File /usr/lib/python3.11/_weakrefset.py:88, in WeakSet.add(self, item)
     86 if self._pending_removals:
     87     self._commit_removals()
---> 88 self.data.add(ref(item, self._remove))

RecursionError: maximum recursion depth exceeded in comparison
```