### PR TITLE
allow getting and setting cmaps in image widget

### DIFF
--- a/fastplotlib/widgets/image.py
+++ b/fastplotlib/widgets/image.py
@@ -114,6 +114,34 @@ class ImageWidget:
         return iw_managed
 
     @property
+    def cmap(self) -> List[str]:
+        cmaps = list()
+        for g in self.managed_graphics:
+            cmaps.append(g.cmap.name)
+
+        return cmaps
+
+    @cmap.setter
+    def cmap(self, names: Union[str, List[str]]):
+        if isinstance(names, list):
+            if not all([isinstance(n, str) for n in names]):
+                raise TypeError(f"Must pass cmap name as a `str` of list of `str`, you have passed:\n{names}")
+
+            if not len(names) == len(self.managed_graphics):
+                raise IndexError(
+                    f"If passing a list of cmap names, the length of the list must be the same as the number of "
+                    f"image widget subplots. You have passed: {len(names)} cmap names and have "
+                    f"{len(self.managed_graphics)} image widget subplots"
+                )
+
+            for name, g in zip(names, self.managed_graphics):
+                g.cmap = name
+
+        elif isinstance(names, str):
+            for g in self.managed_graphics:
+                g.cmap = names
+
+    @property
     def data(self) -> List[np.ndarray]:
         """data currently displayed in the widget"""
         return self._data


### PR DESCRIPTION
Usage:

```python
iw.cmap

# returns list of cmaps, one item per subplot/managed graphic in image widget

# set specific subplot managed graphics
iw.cmap = ["gray", "gnuplot2"]

# set all
iw.cmap = "viridis"
```

After #166 is done we can make it easier to set cmaps in individual subplots for image graphics, but I think this will still be useful for image widget ever after we have that.
