### PR TITLE
add `in` operator to `PlotArea` base

### DIFF
--- a/fastplotlib/layouts/_base.py
+++ b/fastplotlib/layouts/_base.py
@@ -516,6 +516,28 @@ class PlotArea:
             f"The current selectors are:\n {selector_names}"
         )
 
+    def __contains__(self, item: Union[str, Graphic]):
+        to_check = [*self.graphics, *self.selectors]
+
+        if isinstance(item, Graphic):
+            if item in to_check:
+                return True
+            else:
+                return False
+
+        elif isinstance(item, str):
+            for graphic in to_check:
+                # only check named graphics
+                if graphic.name is None:
+                    continue
+
+                if graphic.name == item:
+                    return True
+
+            return False
+
+        raise TypeError("PlotArea `in` operator accepts only `Graphic` or `str` types")
+    
     def __str__(self):
         if self.name is None:
             name = "unnamed"


### PR DESCRIPTION
allows:

```python
"graphic_name" in plot

"graphic_name" in gridplot[0, 0]

graphic_obj in plot

graphic_obj in gridplot[0, 0]
```

usecase example from mesviz, makes it easy to check if a subplot has contours or not, etc. 

![image](https://github.com/fastplotlib/fastplotlib/assets/9403332/a8ee10ae-ab1e-488d-81c2-84be3d24cdd6)
