### PR TITLE
fix cmap_values were not set in the `@setter`

### DIFF
--- a/fastplotlib/graphics/line_collection.py
+++ b/fastplotlib/graphics/line_collection.py
@@ -243,6 +243,8 @@ class LineCollection(GraphicCollection, Interaction):
         for i, g in enumerate(self.graphics):
             g.colors = colors[i]
 
+        self._cmap_values = values
+
     def add_linear_selector(
         self, selection: int = None, padding: float = 50, **kwargs
     ) -> LinearSelector:


### PR DESCRIPTION
This snuck by, our tests aren't actually checking the `@setter`:
https://github.com/fastplotlib/fastplotlib/blob/master/examples/desktop/line_collection/line_collection_cmap_values.py
https://github.com/fastplotlib/fastplotlib/blob/master/examples/desktop/line_collection/line_collection_cmap_values_qualitative.py
