### PR TITLE
histogram lut widget

### DIFF
--- a/examples/notebooks/image_widget.ipynb
+++ b/examples/notebooks/image_widget.ipynb
@@ -44,7 +44,6 @@
    "source": [
     "iw = ImageWidget(\n",
     "    data=a,\n",
-    "    vmin_vmax_sliders=True,\n",
     "    cmap=\"viridis\"\n",
     ")"
    ]
@@ -113,7 +112,6 @@
     "iw = ImageWidget(\n",
     "    data=a, \n",
     "    slider_dims=[\"t\"],\n",
-    "    vmin_vmax_sliders=True,\n",
     "    cmap=\"gnuplot2\"\n",
     ")"
    ]
@@ -247,7 +245,6 @@
     "    data=data, \n",
     "    slider_dims=[\"t\"], \n",
     "    # dims_order=\"txy\", # you can set this manually if dim order is not the usual\n",
-    "    vmin_vmax_sliders=True,\n",
     "    names=[\"zero\", \"one\", \"two\", \"three\"],\n",
     "    window_funcs={\"t\": (np.mean, 5)},\n",
     "    cmap=\"gnuplot2\", \n",
@@ -338,7 +335,6 @@
     "    data=data, \n",
     "    slider_dims=[\"t\", \"z\"], \n",
     "    dims_order=\"xyzt\", # example of how you can set this for non-standard orders\n",
-    "    vmin_vmax_sliders=True,\n",
     "    names=[\"zero\", \"one\", \"two\", \"three\"],\n",
     "    # window_funcs={\"t\": (np.mean, 5)}, # window functions can be slow when indexing multiple dims\n",
     "    cmap=\"gnuplot2\", \n",
@@ -402,7 +398,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/fastplotlib/graphics/selectors/_base_selector.py
+++ b/fastplotlib/graphics/selectors/_base_selector.py
@@ -86,6 +86,8 @@ class BaseSelector(Graphic):
         # sets to `True` on "pointer_down", sets to `False` on "pointer_up"
         self._moving = False  #: indicates if the selector is currently being moved
 
+        self._initial_controller_state: bool = None
+
         # used to disable fill area events if the edge is being actively hovered
         # otherwise annoying and requires too much accuracy to move just an edge
         self._edge_hovered: bool = False
@@ -201,6 +203,8 @@ class BaseSelector(Graphic):
         self._move_info = MoveInfo(last_position=last_position, source=event_source)
         self._moving = True
 
+        self._initial_controller_state = self._plot_area.controller.enabled
+
     def _move(self, ev):
         """
         Called on pointer move events
@@ -235,7 +239,9 @@ class BaseSelector(Graphic):
         # update last position
         self._move_info.last_position = world_pos
 
-        self._plot_area.controller.enabled = True
+        # restore the initial controller state
+        # if it was disabled, keep it disabled
+        self._plot_area.controller.enabled = self._initial_controller_state
 
     def _move_graphic(self, delta: np.ndarray):
         raise NotImplementedError("Must be implemented in subclass")
@@ -243,7 +249,10 @@ class BaseSelector(Graphic):
     def _move_end(self, ev):
         self._move_info = None
         self._moving = False
-        self._plot_area.controller.enabled = True
+
+        # restore the initial controller state
+        # if it was disabled, keep it disabled
+        self._plot_area.controller.enabled = self._initial_controller_state
 
     def _move_to_pointer(self, ev):
         """

--- a/fastplotlib/graphics/selectors/_linear_region.py
+++ b/fastplotlib/graphics/selectors/_linear_region.py
@@ -44,6 +44,7 @@ class LinearRegionSelector(BaseSelector):
         resizable: bool = True,
         fill_color=(0, 0, 0.35),
         edge_color=(0.8, 0.8, 0),
+        edge_thickness: int = 3,
         arrow_keys_modifier: str = "Shift",
         name: str = None,
     ):
@@ -168,7 +169,7 @@ class LinearRegionSelector(BaseSelector):
 
             left_line = pygfx.Line(
                 pygfx.Geometry(positions=left_line_data),
-                pygfx.LineMaterial(thickness=3, color=edge_color),
+                pygfx.LineMaterial(thickness=edge_thickness, color=edge_color),
             )
 
             # position data for the right edge line
@@ -181,7 +182,7 @@ class LinearRegionSelector(BaseSelector):
 
             right_line = pygfx.Line(
                 pygfx.Geometry(positions=right_line_data),
-                pygfx.LineMaterial(thickness=3, color=edge_color),
+                pygfx.LineMaterial(thickness=edge_thickness, color=edge_color),
             )
 
             self.edges: Tuple[pygfx.Line, pygfx.Line] = (left_line, right_line)
@@ -197,7 +198,7 @@ class LinearRegionSelector(BaseSelector):
 
             bottom_line = pygfx.Line(
                 pygfx.Geometry(positions=bottom_line_data),
-                pygfx.LineMaterial(thickness=3, color=edge_color),
+                pygfx.LineMaterial(thickness=edge_thickness, color=edge_color),
             )
 
             # position data for the right edge line
@@ -210,7 +211,7 @@ class LinearRegionSelector(BaseSelector):
 
             top_line = pygfx.Line(
                 pygfx.Geometry(positions=top_line_data),
-                pygfx.LineMaterial(thickness=3, color=edge_color),
+                pygfx.LineMaterial(thickness=edge_thickness, color=edge_color),
             )
 
             self.edges: Tuple[pygfx.Line, pygfx.Line] = (bottom_line, top_line)

--- a/fastplotlib/graphics/selectors/_linear_region.py
+++ b/fastplotlib/graphics/selectors/_linear_region.py
@@ -57,6 +57,9 @@ class LinearRegionSelector(BaseSelector):
         Holding the right mouse button while dragging an edge will force the entire region selector to move. This is
         a when using transparent fill areas due to ``pygfx`` picking limitations.
 
+        **Note:** Events get very weird if the values of bounds, limits and origin are close to zero. If you need
+        a linear selector with small data, we recommend scaling the data and then using the selector.
+
         Parameters
         ----------
         bounds: (int, int)

--- a/fastplotlib/layouts/_subplot.py
+++ b/fastplotlib/layouts/_subplot.py
@@ -1,6 +1,4 @@
 from typing import *
-from inspect import getfullargspec
-from warnings import warn
 
 import numpy as np
 
@@ -97,9 +95,6 @@ class Subplot(PlotArea, GraphicMethodsMixin):
 
         self._grid: GridHelper = GridHelper(size=100, thickness=1)
 
-        self._animate_funcs_pre = list()
-        self._animate_funcs_post = list()
-
         super(Subplot, self).__init__(
             parent=parent,
             position=position,
@@ -191,87 +186,6 @@ class Subplot(PlotArea, GraphicMethodsMixin):
             rect = rect + dv.get_parent_rect_adjust()
 
         return rect
-
-    def render(self):
-        self._call_animate_functions(self._animate_funcs_pre)
-
-        super(Subplot, self).render()
-
-        self._call_animate_functions(self._animate_funcs_post)
-
-    def _call_animate_functions(self, funcs: Iterable[callable]):
-        for fn in funcs:
-            try:
-                args = getfullargspec(fn).args
-
-                if len(args) > 0:
-                    if args[0] == "self" and not len(args) > 1:
-                        fn()
-                    else:
-                        fn(self)
-                else:
-                    fn()
-            except (ValueError, TypeError):
-                warn(
-                    f"Could not resolve argspec of {self.__class__.__name__} animation function: {fn}, "
-                    f"calling it without arguments."
-                )
-                fn()
-
-    def add_animations(
-        self,
-        *funcs: Iterable[callable],
-        pre_render: bool = True,
-        post_render: bool = False,
-    ):
-        """
-        Add function(s) that are called on every render cycle.
-        These are called at the Subplot level.
-
-        Parameters
-        ----------
-        *funcs: callable or iterable of callable
-            function(s) that are called on each render cycle
-
-        pre_render: bool, default ``True``, optional keyword-only argument
-            if true, these function(s) are called before a render cycle
-
-        post_render: bool, default ``False``, optional keyword-only argument
-            if true, these function(s) are called after a render cycle
-
-        """
-        for f in funcs:
-            if not callable(f):
-                raise TypeError(
-                    f"all positional arguments to add_animations() must be callable types, you have passed a: {type(f)}"
-                )
-            if pre_render:
-                self._animate_funcs_pre += funcs
-            if post_render:
-                self._animate_funcs_post += funcs
-
-    def remove_animation(self, func):
-        """
-        Removes the passed animation function from both pre and post render.
-
-        Parameters
-        ----------
-        func: callable
-            The function to remove, raises a error if it's not registered as a pre or post animation function.
-
-        """
-        if func not in self._animate_funcs_pre and func not in self._animate_funcs_post:
-            raise KeyError(
-                f"The passed function: {func} is not registered as an animation function. These are the animation "
-                f" functions that are currently registered:\n"
-                f"pre: {self._animate_funcs_pre}\n\npost: {self._animate_funcs_post}"
-            )
-
-        if func in self._animate_funcs_pre:
-            self._animate_funcs_pre.remove(func)
-
-        if func in self._animate_funcs_post:
-            self._animate_funcs_post.remove(func)
 
     def set_axes_visibility(self, visible: bool):
         """Toggles axes visibility."""

--- a/fastplotlib/widgets/histogram_lut.py
+++ b/fastplotlib/widgets/histogram_lut.py
@@ -38,6 +38,7 @@ class HistogramLUT(Graphic):
             size=size,
             origin=origin,
             axis="y",
+            edge_thickness=8
         )
 
         widget_wo = Group()
@@ -50,6 +51,8 @@ class HistogramLUT(Graphic):
         self.linear_region.selection.add_event_handler(
             self._set_vmin_vmax
         )
+
+        self.image_graphic.cmap.add_event_handler(self._set_selection_from_cmap)
 
     def _add_plot_area_hook(self, plot_area):
         self._plot_area = plot_area
@@ -97,8 +100,22 @@ class HistogramLUT(Graphic):
 
     def _set_vmin_vmax(self, ev):
         selected = self.linear_region.get_selected_data(self.line)[:, 1]
+
+        self.image_graphic.cmap.block_events(True)
+
         self.image_graphic.cmap.vmin = selected[0]
         self.image_graphic.cmap.vmax = selected[-1]
+
+        self.image_graphic.cmap.block_events(False)
+
+    def _set_selection_from_cmap(self, ev):
+        vmin, vmax = ev.pick_info["vmin"], ev.pick_info["vmax"]
+
+        self.linear_region.selection.block_events(True)
+
+        self.linear_region.selection = (vmin, vmax)
+
+        self.linear_region.selection.block_events(False)
 
     def set_data(self, data):
         hist, edges, hist_scaled, edges_flanked = self._calculate_histogram(data)

--- a/fastplotlib/widgets/histogram_lut.py
+++ b/fastplotlib/widgets/histogram_lut.py
@@ -1,0 +1,131 @@
+import numpy as np
+
+from pygfx import Group
+
+from ..graphics import LineGraphic, ImageGraphic
+from ..graphics._base import Graphic
+from ..graphics.selectors import LinearRegionSelector
+
+
+# TODO: This is a widget, we can think about a BaseWidget class later if necessary
+class HistogramLUT(Graphic):
+    def __init__(
+            self,
+            data: np.ndarray,
+            image_graphic: ImageGraphic,
+            nbins: int = 100,
+            **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        self.nbins = nbins
+        self._image_graphic = image_graphic
+
+        hist, edges, hist_scaled, edges_flanked = self._calculate_histogram(data)
+
+        line_data = np.column_stack([hist_scaled, edges_flanked])
+
+        self.line = LineGraphic(line_data)
+
+        bounds = (edges[0], edges[-1])
+        limits = (edges_flanked[0], edges_flanked[-1])
+        size = 120  # since it's scaled to 100
+        origin = (hist_scaled.max() / 2, 0)
+
+        self.linear_region = LinearRegionSelector(
+            bounds=bounds,
+            limits=limits,
+            size=size,
+            origin=origin,
+            axis="y",
+        )
+
+        widget_wo = Group()
+        widget_wo.add(self.line.world_object, self.linear_region.world_object)
+
+        self._set_world_object(widget_wo)
+
+        self.world_object.local.scale_x *= -1
+
+        self.linear_region.selection.add_event_handler(
+            self._set_vmin_vmax
+        )
+
+    def _add_plot_area_hook(self, plot_area):
+        self._plot_area = plot_area
+        self.linear_region._add_plot_area_hook(plot_area)
+        self.line._add_plot_area_hook(plot_area)
+
+    def _calculate_histogram(self, data):
+        if data.ndim > 2:
+            # subsample to max of 500 x 100 x 100,
+            # np.histogram takes ~30ms with this size on a 8 core Ryzen laptop
+            # dim0 is usually time, allow max of 500 timepoints
+            ss0 = int(data.shape[0] / 500)
+            # allow max of 100 for x and y if ndim > 2
+            ss1 = int(data.shape[1] / 100)
+            ss2 = int(data.shape[2] / 100)
+
+            hist, edges = np.histogram(data[::ss0, ::ss1, ::ss2], bins=self.nbins)
+
+        else:
+            # allow max of 1000 x 1000
+            # this takes ~4ms on a 8 core Ryzen laptop
+            ss0 = int(data.shape[0] / 1_000)
+            ss1 = int(data.shape[1] / 1_000)
+
+            hist, edges = np.histogram(data[::ss0, ::ss1], bins=self.nbins)
+
+        bin_width = edges[1] - edges[0]
+
+        flank_nbins = int(self.nbins / 3)
+        flank_size = flank_nbins * bin_width
+
+        flank_left = np.arange(edges[0] - flank_size, edges[0], bin_width)
+        flank_right = np.arange(edges[-1] + bin_width, edges[-1] + flank_size, bin_width)
+
+        edges_flanked = np.concatenate((flank_left, edges, flank_right))
+        np.unique(np.diff(edges_flanked))
+
+        hist_flanked = np.concatenate((np.zeros(flank_nbins), hist, np.zeros(flank_nbins)))
+
+        # scale 0-100 to make it easier to see
+        # float32 data can produce unnecessarily high values
+        hist_scaled = hist_flanked / (hist_flanked.max() / 100)
+
+        return hist, edges, hist_scaled, edges_flanked
+
+    def _set_vmin_vmax(self, ev):
+        selected = self.linear_region.get_selected_data(self.line)[:, 1]
+        self.image_graphic.cmap.vmin = selected[0]
+        self.image_graphic.cmap.vmax = selected[-1]
+
+    def set_data(self, data):
+        hist, edges, hist_scaled, edges_flanked = self._calculate_histogram(data)
+
+        line_data = np.column_stack([hist_scaled, edges_flanked])
+
+        self.line.data = line_data
+
+        bounds = (edges[0], edges[-1])
+        limits = (edges_flanked[0], edges_flanked[-11])
+        origin = (hist_scaled.max() / 2, 0)
+
+        self.linear_region.limits = limits
+        self.linear_region.selection = bounds
+        # self.linear_region.fill.world.position = (*origin, -2)
+
+    # def nbins(self):
+
+    @property
+    def image_graphic(self) -> ImageGraphic:
+        return self._image_graphic
+
+    @image_graphic.setter
+    def image_graphic(self, graphic):
+        if not isinstance(graphic, ImageGraphic):
+            raise TypeError(
+                f"HistogramLUT can only use ImageGraphic types, you have passed: {type(graphic)}"
+            )
+
+        self._image_graphic = graphic

--- a/fastplotlib/widgets/image.py
+++ b/fastplotlib/widgets/image.py
@@ -838,20 +838,8 @@ class ImageWidget:
         """
         Reset the vmin and vmax w.r.t. the currently displayed image(s)
         """
-        for i, ig in enumerate(self.managed_graphics):
-            mm = self._get_vmin_vmax_range(ig.data())
-
-            if len(self.vmin_vmax_sliders) != 0:
-                state = {
-                    "value": mm[0],
-                    "step": mm[1] / 150,
-                    "min": mm[2],
-                    "max": mm[3],
-                }
-
-                self.vmin_vmax_sliders[i].set_state(state)
-            else:
-                ig.cmap.vmin, ig.cmap.vmax = mm[0]
+        for ig in self.managed_graphics:
+            ig.cmap.reset_vmin_vmax()
 
     def set_data(
         self,
@@ -1068,8 +1056,7 @@ class ImageWidgetToolbar:
         self.reset_vminvmax_button.on_click(self._reset_vminvmax)
 
     def _reset_vminvmax(self, obj):
-        if len(self.iw.vmin_vmax_sliders) != 0:
-            self.iw.reset_vmin_vmax()
+        self.iw.reset_vmin_vmax()
 
     def _change_stepsize(self, obj):
         self.iw.sliders["t"].step = self.step_size_setter.value

--- a/fastplotlib/widgets/image.py
+++ b/fastplotlib/widgets/image.py
@@ -9,7 +9,6 @@ from ipywidgets.widgets import (
     VBox,
     HBox,
     Layout,
-    FloatRangeSlider,
     Button,
     BoundedIntText,
     Play,
@@ -21,6 +20,7 @@ from IPython.display import display
 from ..layouts import GridPlot
 from ..graphics import ImageGraphic
 from ..utils import quick_min_max, calculate_gridshape
+from .histogram_lut import HistogramLUT
 
 
 DEFAULT_DIMS_ORDER = {
@@ -220,7 +220,6 @@ class ImageWidget:
         slider_dims: Union[str, int, List[Union[str, int]]] = None,
         window_funcs: Union[int, Dict[str, int]] = None,
         frame_apply: Union[callable, Dict[int, callable]] = None,
-        vmin_vmax_sliders: bool = False,
         grid_shape: Tuple[int, int] = None,
         names: List[str] = None,
         grid_plot_kwargs: dict = None,
@@ -527,8 +526,6 @@ class ImageWidget:
         # current_index stores {dimension_index: slice_index} for every dimension
         self._current_index: Dict[str, int] = {sax: 0 for sax in self.slider_dims}
 
-        self.vmin_vmax_sliders: List[FloatRangeSlider] = list()
-
         # get max bound for all data arrays for all dimensions
         self._dims_max_bounds: Dict[str, int] = {k: np.inf for k in self.slider_dims}
         for _dim in list(self._dims_max_bounds.keys()):
@@ -543,34 +540,10 @@ class ImageWidget:
         self._gridplot: GridPlot = GridPlot(shape=grid_shape, **grid_plot_kwargs)
 
         for data_ix, (d, subplot) in enumerate(zip(self.data, self.gridplot)):
-            minmax = quick_min_max(self.data[data_ix])
-
             if self._names is not None:
                 name = self._names[data_ix]
-                name_slider = name
             else:
                 name = None
-                name_slider = ""
-
-            if vmin_vmax_sliders:
-                data_range = np.ptp(minmax)
-                data_range_40p = np.ptp(minmax) * 0.4
-
-                minmax_slider = FloatRangeSlider(
-                    value=minmax,
-                    min=minmax[0] - data_range_40p,
-                    max=minmax[1] + data_range_40p,
-                    step=data_range / 150,
-                    description=f"mm: {name_slider}",
-                    readout=True,
-                    readout_format=".3f",
-                )
-
-                minmax_slider.observe(
-                    partial(self._vmin_vmax_slider_changed, data_ix), names="value"
-                )
-
-                self.vmin_vmax_sliders.append(minmax_slider)
 
             frame = self._process_indices(d, slice_indices=self._current_index)
             frame = self._process_frame_apply(frame, data_ix)
@@ -578,6 +551,17 @@ class ImageWidget:
             subplot.add_graphic(ig)
             subplot.name = name
             subplot.set_title(name)
+
+            hlut = HistogramLUT(
+                data=d,
+                image_graphic=ig,
+                name="histogram_lut"
+            )
+
+            subplot.docks["right"].add_graphic(hlut)
+            subplot.docks["right"].size = 50
+            subplot.docks["right"].auto_scale(maintain_aspect=False)
+            subplot.docks["right"].controller.enabled = False
 
         self.gridplot.renderer.add_event_handler(self._set_slider_layout, "resize")
 
@@ -601,7 +585,7 @@ class ImageWidget:
 
         # TODO: So just stack everything vertically for now
         self._vbox_sliders = VBox(
-            [*list(self._sliders.values()), *self.vmin_vmax_sliders]
+            [*list(self._sliders.values())]
         )
 
     @property
@@ -795,44 +779,10 @@ class ImageWidget:
             return
         self.current_index = {dimension: change["new"]}
 
-    def _vmin_vmax_slider_changed(self, data_ix: int, change: dict):
-        vmin, vmax = change["new"]
-        self.managed_graphics[data_ix].cmap.vmin = vmin
-        self.managed_graphics[data_ix].cmap.vmax = vmax
-
     def _set_slider_layout(self, *args):
         w, h = self.gridplot.renderer.logical_size
         for k, v in self.sliders.items():
             v.layout = Layout(width=f"{w}px")
-
-        for mm in self.vmin_vmax_sliders:
-            mm.layout = Layout(width=f"{w}px")
-
-    def _get_vmin_vmax_range(self, data: np.ndarray) -> tuple:
-        """
-        Parameters
-        ----------
-        data
-
-        Returns
-        -------
-        Tuple[Tuple[float, float], float, float, float]
-            (min, max), data_range, min - (data_range * 0.4), max + (data_range * 0.4)
-        """
-
-        minmax = quick_min_max(data)
-
-        data_range = np.ptp(minmax)
-        data_range_40p = data_range * 0.4
-
-        _range = (
-            minmax,
-            data_range,
-            minmax[0] - data_range_40p,
-            minmax[1] + data_range_40p,
-        )
-
-        return _range
 
     def reset_vmin_vmax(self):
         """
@@ -914,6 +864,9 @@ class ImageWidget:
             if new_array.ndim > 3:  # tzxy
                 max_lengths["z"] = min(max_lengths["z"], new_array.shape[1] - 1)
 
+            # set histogram widget
+            subplot.docks["right"]["histogram_lut"].set_data(new_array, reset_vmin_vmax=reset_vmin_vmax)
+
         # set slider maxes
         # TODO: maybe make this stuff a property, like ndims, n_frames etc. and have it set the sliders
         for key in self.sliders.keys():
@@ -923,8 +876,8 @@ class ImageWidget:
         # force graphics to update
         self.current_index = self.current_index
 
-        if reset_vmin_vmax:
-            self.reset_vmin_vmax()
+        # if reset_vmin_vmax:
+        #     self.reset_vmin_vmax()
 
     def show(self, toolbar: bool = True, sidecar: bool = True, sidecar_kwargs: dict = None):
         """


### PR DESCRIPTION
closes #166

Also moved animation and render methods from `Subplot` to `PlotBase`, because we need `DockedPlotArea` to use animation functions which is required for `LinearRegionSelector` plot hooks.

https://github.com/fastplotlib/fastplotlib/assets/9403332/c7b10c5d-dc02-48e2-9b08-b664862a4aa4

remaining todo:
- [x] integrate with image widget, removing existing ipywidget sliders
- [x] bidirectional events with associated `ImageGraphic`
- [x] garbage collection, make sure events are cleaned up if switching ImageGraphic too
- ~text to display min and max next to the lines?~ Will do in another PR since text was refactored 
- [x] allow adjusting flank size
- [x] prevent `LinearRegionSelector` from re-enabling the controller when used in docks

For now this is not easily exposed by any imports and only used by `ImageWidget`. We can expose after it stabilizes more and if we're happy with keeping this in `fastplotlib/widgets`.
