### PR TITLE
fix controller getting disabled

### DIFF
--- a/fastplotlib/graphics/selectors/_base_selector.py
+++ b/fastplotlib/graphics/selectors/_base_selector.py
@@ -252,7 +252,8 @@ class BaseSelector(Graphic):
 
         # restore the initial controller state
         # if it was disabled, keep it disabled
-        self._plot_area.controller.enabled = self._initial_controller_state
+        if self._initial_controller_state is not None:
+            self._plot_area.controller.enabled = self._initial_controller_state
 
     def _move_to_pointer(self, ev):
         """


### PR DESCRIPTION
Fix the controller getting disabled since the renderer "pointer_up" event is connected to `BaseSelector._move_end()`
