### PR TITLE
`ImageWidget` notebook tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.png filter=lfs diff=lfs merge=lfs -text
+*.npy filter=lfs diff=lfs merge=lfs -text
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq
-        sudo apt-get install --no-install-recommends -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
+        sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip setuptools

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Show wgpu backend
         run:
           python -c "from examples.tests.testutils import wgpu_backend; print(wgpu_backend)"
+      - name: fetch git lfs files
+        run: |
+          git lfs fetch --all
+          git lfs pull
       - name: Test examples
         env:
           PYGFX_EXPECT_LAVAPIPE: true

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install llvmpipe and lavapipe for offscreen canvas
         run: |
           sudo apt-get update -y -qq
-          sudo apt-get install --no-install-recommends -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+          sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
       - name: Install dev dependencies
         run: |
           python -m pip install --upgrade pip setuptools

--- a/examples/notebooks/image_widget.ipynb
+++ b/examples/notebooks/image_widget.ipynb
@@ -252,7 +252,7 @@
    },
    "outputs": [],
    "source": [
-    "zfish_data = np.load(\"./zfish_test.npy\", allow_pickle=True)\n",
+    "zfish_data = np.load(\"./zfish_test.npy\")\n",
     "# snippet of a dataset from Martin Haesemeyer"
    ]
   },

--- a/examples/notebooks/image_widget.ipynb
+++ b/examples/notebooks/image_widget.ipynb
@@ -16,17 +16,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bc3b4e8b-778a-4e29-a7e9-37d0f871e68d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# this is only for testing, you do not need this to use fastplotlib\n",
-    "from nb_test_utils import plot_test, notebook_finished        "
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "bd632552-dba1-4e48-b8b2-595da7757d0f",
    "metadata": {},
@@ -342,7 +331,7 @@
    },
    "outputs": [],
    "source": [
-    "Fileiw_zfish.gridplot[\"plane-2\"]"
+    "iw_zfish.gridplot[\"plane-2\"]"
    ]
   },
   {
@@ -392,7 +381,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from skimage.filters import gaussian"
+    "# scipy isn't a fastplotlib dependency, it's just used for this example\n",
+    "from scipy.ndimage import gaussian_filter"
    ]
   },
   {
@@ -402,7 +392,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iw_zfish.frame_apply = lambda frame: gaussian(frame, sigma=3)\n",
+    "iw_zfish.frame_apply = lambda frame: gaussian_filter(frame.astype(np.float32), sigma=3)\n",
     "iw_zfish.reset_vmin_vmax()"
    ]
   },

--- a/examples/notebooks/image_widget.ipynb
+++ b/examples/notebooks/image_widget.ipynb
@@ -252,7 +252,7 @@
    },
    "outputs": [],
    "source": [
-    "zfish_data = np.load(\"./zfish_test.npy\")\n",
+    "zfish_data = np.load(\"./zfish_test.npy\", allow_pickle=True)\n",
     "# snippet of a dataset from Martin Haesemeyer"
    ]
   },

--- a/examples/notebooks/image_widget.ipynb
+++ b/examples/notebooks/image_widget.ipynb
@@ -10,7 +10,20 @@
    "outputs": [],
    "source": [
     "from fastplotlib.widgets import ImageWidget\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "\n",
+    "import imageio.v3 as iio  # not a fastplotlib dependency, only used for examples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc3b4e8b-778a-4e29-a7e9-37d0f871e68d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this is only for testing, you do not need this to use fastplotlib\n",
+    "from nb_test_utils import plot_test, notebook_finished        "
    ]
   },
   {
@@ -30,7 +43,8 @@
    },
    "outputs": [],
    "source": [
-    "a = np.random.rand(512, 512)"
+    "# image widget only supports grayscale images for now\n",
+    "a = iio.imread(\"imageio:camera.png\")"
    ]
   },
   {
@@ -63,7 +77,7 @@
    "id": "b718162f-9aa6-4091-a7a4-c620676b48bd",
    "metadata": {},
    "source": [
-    "### can dynamically change features"
+    "### Access graphics managed by the image widget"
    ]
   },
   {
@@ -75,7 +89,7 @@
    },
    "outputs": [],
    "source": [
-    "iw.gridplot[0, 0].graphics[0].cmap = \"gnuplot2\""
+    "iw.gridplot[0, 0][\"image_widget_managed\"].cmap = \"gnuplot2\""
    ]
   },
   {
@@ -95,7 +109,10 @@
    },
    "outputs": [],
    "source": [
-    "a = np.random.rand(500, 512, 512)"
+    "movie = iio.imread(\"imageio:cockatoo.mp4\")\n",
+    "\n",
+    "# convert RGB movie to grayscale, this could take a minute\n",
+    "gray_movie = np.dot(movie[..., :3], [0.299, 0.587, 0.114])"
    ]
   },
   {
@@ -107,10 +124,10 @@
    },
    "outputs": [],
    "source": [
-    "iw2 = ImageWidget(\n",
-    "    data=a, \n",
+    "iw_movie = ImageWidget(\n",
+    "    data=gray_movie, \n",
     "    slider_dims=[\"t\"],\n",
-    "    cmap=\"gnuplot2\"\n",
+    "    cmap=\"gray\"\n",
     ")"
    ]
   },
@@ -123,7 +140,7 @@
    },
    "outputs": [],
    "source": [
-    "iw2.show()"
+    "iw_movie.show(sidecar=True)"
    ]
   },
   {
@@ -146,7 +163,7 @@
    "outputs": [],
    "source": [
     "# must be in the form of {dim: (func, window_size)}\n",
-    "iw2.window_funcs = {\"t\": (np.mean, 13)}"
+    "iw_movie.window_funcs = {\"t\": (np.mean, 13)}"
    ]
   },
   {
@@ -159,7 +176,7 @@
    "outputs": [],
    "source": [
     "# change the winow size\n",
-    "iw2.window_funcs[\"t\"].window_size = 23"
+    "iw_movie.window_funcs[\"t\"].window_size = 33"
    ]
   },
   {
@@ -172,7 +189,7 @@
    "outputs": [],
    "source": [
     "# change the function\n",
-    "iw2.window_funcs[\"t\"].func = np.max"
+    "iw_movie.window_funcs[\"t\"].func = np.max"
    ]
   },
   {
@@ -184,8 +201,8 @@
    },
    "outputs": [],
    "source": [
-    "# or set it again\n",
-    "iw2.window_funcs = {\"t\": (np.min, 11)}"
+    "# or reset it\n",
+    "iw_movie.window_funcs = None"
    ]
   },
   {
@@ -199,14 +216,34 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f9ee0e42-3d41-4613-a508-042c6c2c27e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_data = iio.imread(\"imageio:stent.npz\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b85d2e08-1479-46fc-a429-2d7a265493d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "370d1d24-2944-491f-9da0-fa0c7ed073ef",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "new_data = np.random.rand(500, 512, 512)\n",
-    "iw2.set_data(new_data=new_data)"
+    "iw_movie.set_data(new_data=new_data)\n",
+    "iw_movie.gridplot[0, 0].auto_scale()# sidecar is optional"
    ]
   },
   {
@@ -214,7 +251,7 @@
    "id": "aca22179-1b1f-4c51-97bf-ce2d7044e451",
    "metadata": {},
    "source": [
-    "# Gridplot of txy data"
+    "# Gridplot of tzxy data"
    ]
   },
   {
@@ -226,8 +263,29 @@
    },
    "outputs": [],
    "source": [
-    "dims = (100, 512, 512)\n",
-    "data = [np.random.rand(*dims) for i in range(4)]"
+    "zfish_data = np.load(\"./zfish_test.npy\")\n",
+    "# snippet of a dataset from Martin Haesemeyer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b015720c-3de1-4575-80c5-d6eabe4b305f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# data is tzxy\n",
+    "zfish_data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdff388e-d44c-41ff-a177-801f2695fb88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_planes = zfish_data.shape[1]"
    ]
   },
   {
@@ -239,12 +297,10 @@
    },
    "outputs": [],
    "source": [
-    "iw3 = ImageWidget(\n",
-    "    data=data, \n",
-    "    slider_dims=[\"t\"], \n",
-    "    # dims_order=\"txy\", # you can set this manually if dim order is not the usual\n",
-    "    names=[\"zero\", \"one\", \"two\", \"three\"],\n",
+    "iw_zfish = ImageWidget(\n",
+    "    data=[zfish_data[:, i] for i in range(n_planes)],\n",
     "    window_funcs={\"t\": (np.mean, 5)},\n",
+    "    names=[f\"plane-{i}\" for i in range(n_planes)],\n",
     "    cmap=\"gnuplot2\", \n",
     ")"
    ]
@@ -254,7 +310,7 @@
    "id": "0721dc40-677e-431d-94c6-da59606199cb",
    "metadata": {},
    "source": [
-    "### pan-zoom controllers are all synced in a `ImageWidget`"
+    "pan-zoom controllers are all synced across subplots in a `ImageWidget`"
    ]
   },
   {
@@ -266,7 +322,7 @@
    },
    "outputs": [],
    "source": [
-    "iw3.show()"
+    "iw_zfish.show(sidecar=True)"
    ]
   },
   {
@@ -274,7 +330,7 @@
    "id": "82545214-13c4-475e-87da-962117085834",
    "metadata": {},
    "source": [
-    "### Index the subplots using the names given to `ImageWidget`"
+    "Access the subplots using the names given to `ImageWidget`"
    ]
   },
   {
@@ -286,7 +342,7 @@
    },
    "outputs": [],
    "source": [
-    "iw3.gridplot[\"two\"]"
+    "Fileiw_zfish.gridplot[\"plane-2\"]"
    ]
   },
   {
@@ -294,7 +350,7 @@
    "id": "dc727d1a-681e-4cbf-bfb2-898ceb31cbe0",
    "metadata": {},
    "source": [
-    "### change window functions just like before"
+    "change window functions"
    ]
   },
   {
@@ -306,7 +362,60 @@
    },
    "outputs": [],
    "source": [
-    "iw3.window_funcs[\"t\"].func = np.max"
+    "iw_zfish.window_funcs[\"t\"].func = np.max"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ceeab465-bafa-4834-8775-d0e35bc5c880",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iw_zfish.window_funcs = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e16a503-0213-4e83-abd3-d1fd202cc193",
+   "metadata": {},
+   "source": [
+    "**Frame-apply functions**\n",
+    "\n",
+    "These are applied on a frame before being displayed in the `ImageGraphic`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9557f0a1-b8fd-4dfe-ac3f-47c90ce78625",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from skimage.filters import gaussian"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f87d7e33-93bc-46e3-9cd1-6c648b132841",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iw_zfish.frame_apply = lambda frame: gaussian(frame, sigma=3)\n",
+    "iw_zfish.reset_vmin_vmax()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b0aa161-89f1-48e4-9976-4a6996f1e7e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# remove the frame-apply function\n",
+    "iw_zfish.frame_apply = None\n",
+    "iw_zfish.reset_vmin_vmax()"
    ]
   },
   {
@@ -314,7 +423,11 @@
    "id": "3e89c10f-6e34-4d63-9805-88403d487432",
    "metadata": {},
    "source": [
-    "## Gridplot of volumetric data"
+    "## z-sliders\n",
+    "\n",
+    "ImageWidget will also give you a slider for \"z\" in addition to \"t\" if necessary. \n",
+    "\n",
+    "This example uses the same example data shown above, but displays them in a single subplot and `ImageWidget` provides a z-slider. You can use `window_funcs`, `frame_apply` funcs, etc. There is no difference in `ImageWidget` behavior with the z-slider."
    ]
   },
   {
@@ -326,15 +439,9 @@
    },
    "outputs": [],
    "source": [
-    "dims = (256, 256, 5, 100)\n",
-    "data = [np.random.rand(*dims) for i in range(4)]\n",
-    "\n",
-    "iw4 = ImageWidget(\n",
-    "    data=data, \n",
-    "    slider_dims=[\"t\", \"z\"], \n",
-    "    dims_order=\"xyzt\", # example of how you can set this for non-standard orders\n",
-    "    names=[\"zero\", \"one\", \"two\", \"three\"],\n",
-    "    # window_funcs={\"t\": (np.mean, 5)}, # window functions can be slow when indexing multiple dims\n",
+    "iw_z = ImageWidget(\n",
+    "    data=zfish_data, # you can also provide a list of tzxy arrays\n",
+    "    window_funcs={\"t\": (np.mean, 5)},\n",
     "    cmap=\"gnuplot2\", \n",
     ")"
    ]
@@ -348,28 +455,16 @@
    },
    "outputs": [],
    "source": [
-    "iw4.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2382809c-4c7d-4da4-9955-71d316dee46a",
-   "metadata": {},
-   "source": [
-    "### window functions, can be slow when you have \"t\" and \"z\""
+    "iw_z.show()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd4433a9-2add-417c-a618-5891371efae0",
-   "metadata": {
-    "tags": []
-   },
+   "id": "aba0fa3a-f844-4937-8615-adbded02345d",
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "iw4.window_funcs = {\"t\": (np.mean, 11)}"
-   ]
+   "source": []
   }
  ],
  "metadata": {
@@ -388,7 +483,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/image_widget_test.ipynb
+++ b/examples/notebooks/image_widget_test.ipynb
@@ -242,7 +242,7 @@
    },
    "outputs": [],
    "source": [
-    "zfish_data = np.load(\"./zfish_test.npy\", allow_pickle=True)"
+    "zfish_data = np.load(\"./zfish_test.npy\")"
    ]
   },
   {

--- a/examples/notebooks/image_widget_test.ipynb
+++ b/examples/notebooks/image_widget_test.ipynb
@@ -11,7 +11,7 @@
    "source": [
     "from fastplotlib.widgets import ImageWidget\n",
     "import numpy as np\n",
-    "from skimage.filters import gaussian\n",
+    "from scipy.ndimage import gaussian_filter\n",
     "\n",
     "import imageio.v3 as iio"
    ]
@@ -318,7 +318,7 @@
     "iw_zfish.window_funcs = {\"t\": (np.max, 13)}\n",
     "plot_test(\"image-widget-zfish-grid-frame-50-max-window-13\", iw_zfish.gridplot)\n",
     "iw_zfish.window_funcs = None\n",
-    "iw_zfish.frame_apply = lambda frame: gaussian(frame, sigma=3)\n",
+    "iw_zfish.frame_apply = lambda frame: gaussian_filter(frame.astype(np.float32), sigma=3)\n",
     "iw_zfish.reset_vmin_vmax()\n",
     "plot_test(\"image-widget-zfish-grid-frame-50-frame-apply-gaussian\", iw_zfish.gridplot)\n",
     "iw_zfish.frame_apply = None\n",
@@ -417,7 +417,7 @@
     "iw_z.window_funcs = {\"t\": (np.max, 13)}\n",
     "plot_test(\"image-widget-zfish-frame-50-max-window-13\", iw_z.gridplot)\n",
     "iw_z.window_funcs = None\n",
-    "iw_z.frame_apply = lambda frame: gaussian(frame, sigma=3)\n",
+    "iw_z.frame_apply = lambda frame: gaussian_filter(frame.astype(np.float32), sigma=3)\n",
     "iw_z.reset_vmin_vmax()\n",
     "plot_test(\"image-widget-zfish-frame-50-frame-apply-gaussian\", iw_z.gridplot)\n",
     "iw_z.frame_apply = None\n",

--- a/examples/notebooks/image_widget_test.ipynb
+++ b/examples/notebooks/image_widget_test.ipynb
@@ -242,7 +242,7 @@
    },
    "outputs": [],
    "source": [
-    "zfish_data = np.load(\"./zfish_test.npy\")"
+    "zfish_data = np.load(\"./zfish_test.npy\", allow_pickle=True)"
    ]
   },
   {

--- a/examples/notebooks/image_widget_test.ipynb
+++ b/examples/notebooks/image_widget_test.ipynb
@@ -1,0 +1,468 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07019035-83f2-4753-9e7c-628ae439b441",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from fastplotlib.widgets import ImageWidget\n",
+    "import numpy as np\n",
+    "from skimage.filters import gaussian\n",
+    "\n",
+    "import imageio.v3 as iio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10b8ab40-944d-472c-9b7e-cae8a129e7ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nb_test_utils import plot_test, notebook_finished        "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a9fe48a-cc24-4ecf-b442-b7425ce338d3",
+   "metadata": {},
+   "source": [
+    "# Single image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01dd4b84-2960-4c26-8162-f0499698e593",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "a = iio.imread(\"imageio:camera.png\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9d98a12-9574-4b47-9271-013e659cb93f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "iw = ImageWidget(\n",
+    "    data=a,\n",
+    "    cmap=\"viridis\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9d86a12-b5f2-4ad7-bd70-4715c80b5ece",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iw.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "920ef882-e5e6-45b6-b002-5ed26aa3134e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_test(\"image-widget-single\", iw.gridplot)\n",
+    "iw.gridplot[0, 0][\"image_widget_managed\"].cmap = \"gnuplot2\"\n",
+    "plot_test(\"image-widget-single-gnuplot2\", iw.gridplot)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26120b76-c7b0-4e23-bdb1-411be1944687",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iw.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffde9820-b388-4f22-b7fd-d55a2ad421ad",
+   "metadata": {},
+   "source": [
+    "# Single image sequence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2067c88f-2b71-4036-a413-59355fa64292",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "movie = iio.imread(\"imageio:cockatoo.mp4\")\n",
+    "\n",
+    "# convert RGB movie to grayscale, this could take a minute\n",
+    "gray_movie = np.dot(movie[..., :3], [0.299, 0.587, 0.114])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05d3a905-849b-42ae-82ac-34bdc28c1414",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "iw_movie = ImageWidget(\n",
+    "    data=gray_movie, \n",
+    "    slider_dims=[\"t\"],\n",
+    "    cmap=\"gray\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92df8b8c-8d9f-4111-9b3b-fdab7cc7b3f4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "iw_movie.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac0a7fc0-0323-4b9e-8c70-3ddc735b7893",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# testing cell ignore\n",
+    "assert iw_movie.sliders[\"t\"].max == gray_movie.shape[0] - 1\n",
+    "assert iw_movie.sliders[\"t\"].min == 0\n",
+    "plot_test(\"image-widget-movie-single-0\", iw_movie.gridplot)\n",
+    "iw_movie.sliders[\"t\"].value = 50\n",
+    "plot_test(\"image-widget-movie-single-50\", iw_movie.gridplot)\n",
+    "iw_movie.sliders[\"t\"].value = 279\n",
+    "plot_test(\"image-widget-movie-single-279\", iw_movie.gridplot)\n",
+    "iw_movie.sliders[\"t\"].value = 0\n",
+    "plot_test(\"image-widget-movie-single-0-reset\", iw_movie.gridplot)\n",
+    "iw_movie.sliders[\"t\"].value = 50\n",
+    "iw_movie.window_funcs = {\"t\": (np.mean, 13)}\n",
+    "# testing cell ignore\n",
+    "plot_test(\"image-widget-movie-single-50-window-mean-13\", iw_movie.gridplot)\n",
+    "iw_movie.window_funcs[\"t\"].window_size = 33\n",
+    "plot_test(\"image-widget-movie-single-50-window-mean-33\", iw_movie.gridplot)\n",
+    "iw_movie.window_funcs[\"t\"].func = np.max\n",
+    "plot_test(\"image-widget-movie-single-50-window-max-33\", iw_movie.gridplot)\n",
+    "iw_movie.window_funcs = None\n",
+    "plot_test(\"image-widget-movie-single-50-window-reset\", iw_movie.gridplot)\n",
+    "iw_movie.sliders[\"t\"].value = 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5fb9aaa-b1a8-46b9-81a5-a656183ab16d",
+   "metadata": {},
+   "source": [
+    "# Set new data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1730287-41de-4166-8d00-36ae2daabb47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_data = iio.imread(\"imageio:stent.npz\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9010dd43-83c8-4807-8874-71af8ef5c955",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "iw_movie.set_data(new_data=new_data)\n",
+    "iw_movie.gridplot[0, 0].auto_scale()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06e6f4fb-fe58-40f0-adf0-191e02cdbd75",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_test(\"image-widget-movie-set_data\", iw_movie.gridplot)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5d55d4e-57f2-4460-b252-7a9d21f7c217",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iw_movie.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2e6819b-209a-49af-97b7-0b8956023d1a",
+   "metadata": {},
+   "source": [
+    "# zfish"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf9845b6-1cda-403b-96cd-e2b51803c96a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "zfish_data = np.load(\"./zfish_test.npy\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7f0315a-29c0-4852-9d49-edaeb3ee45c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# data is tzxy\n",
+    "zfish_data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67e840fa-9eb9-4705-ab85-ec981ba29abb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_planes = zfish_data.shape[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76535d56-e514-4c16-aa48-a6359f8019d5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "iw_zfish = ImageWidget(\n",
+    "    data=[zfish_data[:, i] for i in range(n_planes)],\n",
+    "    window_funcs={\"t\": (np.mean, 5)},\n",
+    "    names=[f\"plane-{i}\" for i in range(n_planes)],\n",
+    "    cmap=\"gnuplot2\", \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13904849-cbc5-41e7-ad90-d6e8a4fc0077",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "iw_zfish.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75e8cf08-f1d2-414c-84a2-1ba4c2a01072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# testing cell ignore\n",
+    "assert iw_zfish.sliders[\"t\"].max == zfish_data.shape[0] - 1\n",
+    "assert iw_zfish.sliders[\"t\"].min == 0\n",
+    "plot_test(\"image-widget-zfish-grid-init-mean-window-5\", iw_zfish.gridplot)\n",
+    "iw_zfish.sliders[\"t\"].value = 50\n",
+    "plot_test(\"image-widget-zfish-grid-frame-50-mean-window-5\", iw_zfish.gridplot)\n",
+    "iw_zfish.window_funcs[\"t\"].window_size = 13\n",
+    "plot_test(\"image-widget-zfish-grid-frame-50-mean-window-13\", iw_zfish.gridplot)\n",
+    "iw_zfish.window_funcs = None\n",
+    "plot_test(\"image-widget-zfish-grid-frame-50\", iw_zfish.gridplot)\n",
+    "iw_zfish.sliders[\"t\"].value = 99\n",
+    "plot_test(\"image-widget-zfish-grid-frame-99\", iw_zfish.gridplot)\n",
+    "iw_zfish.sliders[\"t\"].value = 50\n",
+    "iw_zfish.window_funcs = {\"t\": (np.max, 13)}\n",
+    "plot_test(\"image-widget-zfish-grid-frame-50-max-window-13\", iw_zfish.gridplot)\n",
+    "iw_zfish.window_funcs = None\n",
+    "iw_zfish.frame_apply = lambda frame: gaussian(frame, sigma=3)\n",
+    "iw_zfish.reset_vmin_vmax()\n",
+    "plot_test(\"image-widget-zfish-grid-frame-50-frame-apply-gaussian\", iw_zfish.gridplot)\n",
+    "iw_zfish.frame_apply = None\n",
+    "iw_zfish.reset_vmin_vmax()\n",
+    "plot_test(\"image-widget-zfish-grid-frame-50-frame-apply-reset\", iw_zfish.gridplot)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34499f45-cab3-4abd-832a-a679746b1684",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# reverse planes and test set_data\n",
+    "iw_zfish.set_data(\n",
+    "    [zfish_data[:, i] for i in range(n_planes - 1, -1, -1)],\n",
+    "    reset_indices=False\n",
+    ")\n",
+    "\n",
+    "plot_test(\"image-widget-zfish-grid-set_data-reset-indices-false\", iw_zfish.gridplot)\n",
+    "\n",
+    "iw_zfish.set_data(\n",
+    "    [zfish_data[:, i] for i in range(n_planes - 1, -1, -1)],\n",
+    "    reset_indices=True\n",
+    ")\n",
+    "plot_test(\"image-widget-zfish-grid-set_data-reset-indices-true\", iw_zfish.gridplot)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08501aad-8b56-4ae5-98ff-26942cbb5d67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iw_zfish.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf5ff2c3-780c-41dd-91a7-74ef8b87d838",
+   "metadata": {},
+   "source": [
+    "## z-sliders"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87280ff7-5009-46a7-9306-0c1fe03ba4bd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "iw_z = ImageWidget(\n",
+    "    data=zfish_data, # you can also provide a list of tzxy arrays\n",
+    "    window_funcs={\"t\": (np.mean, 5)},\n",
+    "    cmap=\"gnuplot2\", \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94142bdf-78d0-4512-b27a-f5a61b9aba5f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "iw_z.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06b66964-b3bf-4545-a0e6-79ddc996a1d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# same tests as with the gridplot\n",
+    "assert iw_z.sliders[\"t\"].max == zfish_data.shape[0] - 1\n",
+    "assert iw_z.sliders[\"t\"].min == 0\n",
+    "plot_test(\"image-widget-zfish-init-mean-window-5\", iw_z.gridplot)\n",
+    "iw_z.sliders[\"t\"].value = 50\n",
+    "plot_test(\"image-widget-zfish-frame-50-mean-window-5\", iw_z.gridplot)\n",
+    "iw_z.window_funcs[\"t\"].window_size = 13\n",
+    "plot_test(\"image-widget-zfish-frame-50-mean-window-13\", iw_z.gridplot)\n",
+    "iw_z.window_funcs = None\n",
+    "plot_test(\"image-widget-zfish-frame-50\", iw_z.gridplot)\n",
+    "iw_z.sliders[\"t\"].value = 99\n",
+    "plot_test(\"image-widget-zfish-frame-99\", iw_z.gridplot)\n",
+    "iw_z.sliders[\"t\"].value = 50\n",
+    "iw_z.window_funcs = {\"t\": (np.max, 13)}\n",
+    "plot_test(\"image-widget-zfish-frame-50-max-window-13\", iw_z.gridplot)\n",
+    "iw_z.window_funcs = None\n",
+    "iw_z.frame_apply = lambda frame: gaussian(frame, sigma=3)\n",
+    "iw_z.reset_vmin_vmax()\n",
+    "plot_test(\"image-widget-zfish-frame-50-frame-apply-gaussian\", iw_z.gridplot)\n",
+    "iw_z.frame_apply = None\n",
+    "iw_z.reset_vmin_vmax()\n",
+    "plot_test(\"image-widget-zfish-frame-50-frame-apply-reset\", iw_z.gridplot)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b94ae517-4a48-4efe-b85b-7679ae02d233",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iw_z.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "870627ef-09d8-44e4-8952-aedb702d1526",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/screenshots/nb-image-widget-movie-set_data.png
+++ b/examples/notebooks/screenshots/nb-image-widget-movie-set_data.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df2f6e73fdb0946d915f40df1e27f2ae89ba6c6e5d0dadb84406fe8b753735ab
+size 34974

--- a/examples/notebooks/screenshots/nb-image-widget-movie-single-0-reset.png
+++ b/examples/notebooks/screenshots/nb-image-widget-movie-single-0-reset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b9187c64b7439f629a87a3828cc46a855e1b4609eca52d5484223d2c24e8bf7
+size 62562

--- a/examples/notebooks/screenshots/nb-image-widget-movie-single-0.png
+++ b/examples/notebooks/screenshots/nb-image-widget-movie-single-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b9187c64b7439f629a87a3828cc46a855e1b4609eca52d5484223d2c24e8bf7
+size 62562

--- a/examples/notebooks/screenshots/nb-image-widget-movie-single-279.png
+++ b/examples/notebooks/screenshots/nb-image-widget-movie-single-279.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11eb83e3489a8e9c55fcffb0e67f1cf773e538629ddf98e109601749927caa56
+size 72525

--- a/examples/notebooks/screenshots/nb-image-widget-movie-single-50-window-max-33.png
+++ b/examples/notebooks/screenshots/nb-image-widget-movie-single-50-window-max-33.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51bc6a90fba5c67935838b8e44dca477e250cbc4ee2b98ddd69f931e683ec17a
+size 63906

--- a/examples/notebooks/screenshots/nb-image-widget-movie-single-50-window-mean-13.png
+++ b/examples/notebooks/screenshots/nb-image-widget-movie-single-50-window-mean-13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a2318ab1f242d70045b9784337e4421c635b2345331b6a5e8edc0f32ff15f07
+size 54432

--- a/examples/notebooks/screenshots/nb-image-widget-movie-single-50-window-mean-33.png
+++ b/examples/notebooks/screenshots/nb-image-widget-movie-single-50-window-mean-33.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c5b5df5b0efb0b3b641129e08429e4a92bd5d2c62b1c63c97337287867d685e
+size 50341

--- a/examples/notebooks/screenshots/nb-image-widget-movie-single-50-window-reset.png
+++ b/examples/notebooks/screenshots/nb-image-widget-movie-single-50-window-reset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2e5a5734992333165ef2d5f6f810d869e157e59fb7f54c8dd5f413ac750a3fa
+size 65067

--- a/examples/notebooks/screenshots/nb-image-widget-movie-single-50.png
+++ b/examples/notebooks/screenshots/nb-image-widget-movie-single-50.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2e5a5734992333165ef2d5f6f810d869e157e59fb7f54c8dd5f413ac750a3fa
+size 65067

--- a/examples/notebooks/screenshots/nb-image-widget-single-gnuplot2.png
+++ b/examples/notebooks/screenshots/nb-image-widget-single-gnuplot2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10912f4358278fb26c5efa030a335b0bdb80ebcc2a57fd97838fea3780f9f5d1
+size 143543

--- a/examples/notebooks/screenshots/nb-image-widget-single.png
+++ b/examples/notebooks/screenshots/nb-image-widget-single.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf23c969c93bc526244360af4babf72a1377a171f55b1f44443dc026faf12631
+size 134432

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-frame-50-frame-apply-gaussian.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-frame-50-frame-apply-gaussian.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49b65e35bb12e0bce8e753f6700084b2e1100eb6efd0336afc219d9e26972901
+size 64206

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-frame-50-frame-apply-reset.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-frame-50-frame-apply-reset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df13f86bb18ad52f962f8944cd780579440b4e1d40941019632d4f46a4d9dc2d
+size 50107

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-frame-50-max-window-13.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-frame-50-max-window-13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42676358a0199022972b69263c32a977f90a27ce6c3789d18129c67e9b730679
+size 121369

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-frame-50-mean-window-13.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-frame-50-mean-window-13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3d1972c575f1659fc2c611a2c703cb408b74ca47e30c2e4564641dc0a6ad887
+size 76550

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-frame-50-mean-window-5.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-frame-50-mean-window-5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e24ea022d48ff41174206e43da911632f38237f6250340f73a7169a43d55f2a6
+size 72238

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-frame-50.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-frame-50.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:983cf6804561b4287f6acfdac04e2a31810c9d3191108e2da4623cbb852258d5
+size 56707

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-frame-99.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-frame-99.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e6f528bf9508397a97e33d463ccd8b3584d3ebd04499b976b4989e001648626
+size 45174

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-50-frame-apply-gaussian.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-50-frame-apply-gaussian.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69f8a085b84ee851ad1579791ff96fe6bc73551d86f376524d1194c43edf819f
+size 74941

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-50-frame-apply-reset.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-50-frame-apply-reset.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0616c08a8cf008fbc976638cfb7d76d533547bdb6cbfa56071567dac3c7e703d
+size 75619

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-50-max-window-13.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-50-max-window-13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4f7893445c9f2d26f126a5ac87c1fdf0737b31fec730f754ba4c771eae5ec5b
+size 116744

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-50-mean-window-13.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-50-mean-window-13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a73e0ef31acf4304bc9a649f0761e0d282eb4517ade89538edfe6b7d8a9b61d0
+size 75487

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-50-mean-window-5.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-50-mean-window-5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00ade44cd4478bf77e7bd33ccee64e2905136e35620171f013be7e90ddaa0ba6
+size 79123

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-50.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-50.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eb4d6a4cfbdbfffc198dbe5987f621e5cc3fdcf574699c544a12cf3b28bcdb7
+size 82281

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-99.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-grid-frame-99.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:758c4f444ab3792c6328e51d619c51f59f27fe2589795cc82bdef7fb5daf57e3
+size 79663

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-grid-init-mean-window-5.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-grid-init-mean-window-5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b75c179afde357fd69d7c3e918ad34e072685c536e388b1424596bd493b041e8
+size 81563

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-grid-set_data-reset-indices-false.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-grid-set_data-reset-indices-false.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6d9460835d55d696ffcef1bff7cb7a86672d4c7345112c62050312669055870
+size 66010

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-grid-set_data-reset-indices-true.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-grid-set_data-reset-indices-true.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b83f6353ce227d76fbf7362218bcc35afa26216e5600cf145cbcce666bb6dd6
+size 66520

--- a/examples/notebooks/screenshots/nb-image-widget-zfish-init-mean-window-5.png
+++ b/examples/notebooks/screenshots/nb-image-widget-zfish-init-mean-window-5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:130c7a58ceee6ffe0ec58f194bce04e6f0892c97448b43ef9f90ced85c9c10ba
+size 62566

--- a/examples/notebooks/zfish_test.npy
+++ b/examples/notebooks/zfish_test.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff73fdbde34cafaf01254b9e72bdc484d865e6c3288ef88fc1953f349fc02152
+size 26214528

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extras_require = {
         "pytest",
         "nbmake",
         "scipy",
-        "imageio",
+        "imageio[pyav]",
         "jupyterlab",
         "jupyter-rfb>=0.4.1",
         "ipywidgets>=8.0.0,<9",


### PR DESCRIPTION
Adds tests for ImageWidget in notebooks and fixes up a few things in `ImageWidget` so that `frame_apply` and `window_funcs` take effect without having to move the slider.

ImageWidget tests:
- [x] single image
- [x] movies display
  - [x] changing time slider
  - [x] window functions
  - [x] frame_apply functions
  - [x] set_data
- [x] movies gridplot
  - [x] changing time slider
  - [x] window functions
  - [x] frame_apply functions
  - [x] set_data