### PR TITLE
histogram LUT calculation fix, kinda

### DIFF
--- a/fastplotlib/widgets/histogram_lut.py
+++ b/fastplotlib/widgets/histogram_lut.py
@@ -180,7 +180,8 @@ class HistogramLUT(Graphic):
         hist_scaled = hist_flanked / (hist_flanked.max() / 100)
 
         if edges_flanked.size > hist_scaled.size:
-            edges_flanked = edges_flanked[:-1]
+            # we don't care about accuracy here so if it's off by 1-2 bins that's fine
+            edges_flanked = edges_flanked[:hist_scaled.size]
 
         return hist, edges, hist_scaled, edges_flanked
 


### PR DESCRIPTION
this is a visual tool so we don't care much about accuracy, remove the last 1-2 bins so edges.size == hist.size

The last 2 should be zeros from the flank anyways
