### PR TITLE
add `Deleted` as a graphic feature

### DIFF
--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from pygfx import WorldObject
 
-from ._features import GraphicFeature, PresentFeature, GraphicFeatureIndexable
+from ._features import GraphicFeature, PresentFeature, GraphicFeatureIndexable, Deleted
 
 # dict that holds all world objects for a given python kernel/session
 # Graphic objects only use proxies to WorldObjects
@@ -45,6 +45,12 @@ class BaseGraphic:
 
 
 class Graphic(BaseGraphic):
+    feature_events = {}
+
+    def __init_subclass__(cls, **kwargs):
+        # all graphics give off a feature event when deleted
+        cls.feature_events = {*cls.feature_events, "deleted"}
+
     def __init__(
         self,
         name: str = None,
@@ -71,6 +77,8 @@ class Graphic(BaseGraphic):
 
         # store hex id str of Graphic instance mem location
         self.loc: str = hex(id(self))
+
+        self.deleted = Deleted(self, False)
 
     @property
     def world_object(self) -> WorldObject:
@@ -168,6 +176,7 @@ class Graphic(BaseGraphic):
         pass
 
     def __del__(self):
+        self.deleted = True
         del WORLD_OBJECTS[self.loc]
 
 

--- a/fastplotlib/graphics/_features/__init__.py
+++ b/fastplotlib/graphics/_features/__init__.py
@@ -5,6 +5,7 @@ from ._present import PresentFeature
 from ._thickness import ThicknessFeature
 from ._base import GraphicFeature, GraphicFeatureIndexable, FeatureEvent, to_gpu_supported_dtype
 from ._selection_features import LinearSelectionFeature, LinearRegionSelectionFeature
+from ._deleted import Deleted
 
 __all__ = [
     "ColorFeature",
@@ -23,4 +24,5 @@ __all__ = [
     "to_gpu_supported_dtype",
     "LinearSelectionFeature",
     "LinearRegionSelectionFeature",
+    "Deleted",
 ]

--- a/fastplotlib/graphics/_features/_deleted.py
+++ b/fastplotlib/graphics/_features/_deleted.py
@@ -1,0 +1,41 @@
+from ._base import GraphicFeature, FeatureEvent
+
+
+class Deleted(GraphicFeature):
+    """
+    Used when a graphic is deleted, triggers events that can be useful to indicate this graphic has been deleted
+
+    **event pick info:**
+
+     ==================== ======================== =========================================================================
+      key                  type                     description
+     ==================== ======================== =========================================================================
+      "collection-index"   int                      the index of the graphic within the collection that triggered the event
+      "world_object"       pygfx.WorldObject        world object
+     ==================== ======================== =========================================================================
+    """
+
+    def __init__(self, parent, value: bool):
+        super(Deleted, self).__init__(parent, value)
+
+    def _set(self, value: bool):
+        value = self._parse_set_value(value)
+        self._feature_changed(key=None, new_data=value)
+
+    def _feature_changed(self, key, new_data):
+        # this is a non-indexable feature so key=None
+
+        pick_info = {
+            "index": None,
+            "collection-index": self._collection_index,
+            "world_object": self._parent.world_object,
+            "new_data": new_data,
+        }
+
+        event_data = FeatureEvent(type="deleted", pick_info=pick_info)
+
+        self._call_event_handlers(event_data)
+
+    def __repr__(self) -> str:
+        s = f"DeletedFeature for {self._parent}"
+        return s

--- a/fastplotlib/graphics/image.py
+++ b/fastplotlib/graphics/image.py
@@ -196,7 +196,7 @@ class _AddSelectorsMixin:
 
 
 class ImageGraphic(Graphic, Interaction, _AddSelectorsMixin):
-    feature_events = ("data", "cmap", "present")
+    feature_events = {"data", "cmap", "present"}
 
     def __init__(
         self,
@@ -345,10 +345,11 @@ class _ImageTile(pygfx.Image):
 
 
 class HeatmapGraphic(Graphic, Interaction, _AddSelectorsMixin):
-    feature_events = (
+    feature_events = {
         "data",
         "cmap",
-    )
+        "present"
+    }
 
     def __init__(
         self,

--- a/fastplotlib/graphics/line.py
+++ b/fastplotlib/graphics/line.py
@@ -12,7 +12,7 @@ from .selectors import LinearRegionSelector, LinearSelector
 
 
 class LineGraphic(Graphic, Interaction):
-    feature_events = ("data", "colors", "cmap", "thickness", "present")
+    feature_events = {"data", "colors", "cmap", "thickness", "present"}
 
     def __init__(
         self,

--- a/fastplotlib/graphics/line_collection.py
+++ b/fastplotlib/graphics/line_collection.py
@@ -15,7 +15,7 @@ from .selectors import LinearRegionSelector, LinearSelector
 
 class LineCollection(GraphicCollection, Interaction):
     child_type = LineGraphic.__name__
-    feature_events = ("data", "colors", "cmap", "thickness", "present")
+    feature_events = {"data", "colors", "cmap", "thickness", "present"}
 
     def __init__(
         self,

--- a/fastplotlib/graphics/scatter.py
+++ b/fastplotlib/graphics/scatter.py
@@ -9,7 +9,7 @@ from ._features import PointsDataFeature, ColorFeature, CmapFeature, PointsSizes
 
 
 class ScatterGraphic(Graphic):
-    feature_events = ("data", "sizes", "colors", "cmap", "present")
+    feature_events = {"data", "sizes", "colors", "cmap", "present"}
 
     def __init__(
         self,


### PR DESCRIPTION
This makes it possible to create callbacks to do things when a `Graphic` is deleted from a `PlotArea`.

~garbage collection is actinng wonky again so I need to fix that too...~ nevermind, I think was accessing stuff users wouldn't normally access in jupyter so ipython was clinging onto it, as usual :smile: 

This also changes all `feature_events` class attributes to be a `set`.

Useage:
![image](https://github.com/fastplotlib/fastplotlib/assets/9403332/44a1d93f-e055-49af-8e12-e47e050f4ddd)
