### PR TITLE
add gif files to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 *.png filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
 *.npy filter=lfs diff=lfs merge=lfs -text
-


### PR DESCRIPTION
I missed this somehow, but github still stored the gif file using git-lfs before I put in this specification :man_shrugging: 
