### PR TITLE
Lazy import av

### DIFF
--- a/fastplotlib/layouts/_frame/_toolbar.py
+++ b/fastplotlib/layouts/_frame/_toolbar.py
@@ -1,4 +1,4 @@
-from fastplotlib.layouts._subplot import Subplot
+from .._subplot import Subplot
 
 
 class ToolBar:


### PR DESCRIPTION
After #431 I did a review of all imports. I found 2 small interesting cases, which are addressed in this PR:

* One absolute import of a fastplotlib module.
* The optional dependency `av` can easily be lazy-imported (shaving nearly 0.1 off the import time on my machine).