### PR TITLE
Use simpler form of super() where possible

### DIFF
--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -408,7 +408,7 @@ class GraphicCollection(Graphic):
     """Graphic Collection base class"""
 
     def __init__(self, name: str = None):
-        super(GraphicCollection, self).__init__(name)
+        super().__init__(name)
         self._graphics: List[str] = list()
 
         self._graphics_changed: bool = True

--- a/fastplotlib/graphics/_features/_colors.py
+++ b/fastplotlib/graphics/_features/_colors.py
@@ -251,7 +251,8 @@ class CmapFeature(ColorFeature):
     """
 
     def __init__(self, parent, colors, cmap_name: str, cmap_values: np.ndarray):
-        super().__init__(parent, colors)
+        # Skip the ColorFeature's __init__
+        super(ColorFeature, self).__init__(self, parent, colors)
 
         self._cmap_name = cmap_name
         self._cmap_values = cmap_values

--- a/fastplotlib/graphics/_features/_colors.py
+++ b/fastplotlib/graphics/_features/_colors.py
@@ -252,7 +252,7 @@ class CmapFeature(ColorFeature):
 
     def __init__(self, parent, colors, cmap_name: str, cmap_values: np.ndarray):
         # Skip the ColorFeature's __init__
-        super(ColorFeature, self).__init__(self, parent, colors)
+        super(ColorFeature, self).__init__(parent, colors)
 
         self._cmap_name = cmap_name
         self._cmap_values = cmap_values

--- a/fastplotlib/graphics/_features/_colors.py
+++ b/fastplotlib/graphics/_features/_colors.py
@@ -124,9 +124,7 @@ class ColorFeature(GraphicFeatureIndexable):
         if alpha != 1.0:
             data[:, -1] = alpha
 
-        super(ColorFeature, self).__init__(
-            parent, data, collection_index=collection_index
-        )
+        super().__init__(parent, data, collection_index=collection_index)
 
     def __setitem__(self, key, value):
         # parse numerical slice indices
@@ -253,7 +251,7 @@ class CmapFeature(ColorFeature):
     """
 
     def __init__(self, parent, colors, cmap_name: str, cmap_values: np.ndarray):
-        super(ColorFeature, self).__init__(parent, colors)
+        super().__init__(parent, colors)
 
         self._cmap_name = cmap_name
         self._cmap_values = cmap_values
@@ -278,7 +276,7 @@ class CmapFeature(ColorFeature):
         )
 
         self._cmap_name = cmap_name
-        super(CmapFeature, self).__setitem__(key, colors)
+        super().__setitem__(key, colors)
 
     @property
     def name(self) -> str:
@@ -299,7 +297,7 @@ class CmapFeature(ColorFeature):
 
         self._cmap_values = values
 
-        super(CmapFeature, self).__setitem__(slice(None), colors)
+        super().__setitem__(slice(None), colors)
 
     def __repr__(self) -> str:
         s = f"CmapFeature for {self._parent}, to get name or values: `<graphic>.cmap.name`, `<graphic>.cmap.values`"
@@ -330,7 +328,7 @@ class ImageCmapFeature(GraphicFeature):
 
     def __init__(self, parent, cmap: str):
         cmap_texture_view = get_cmap_texture(cmap)
-        super(ImageCmapFeature, self).__init__(parent, cmap_texture_view)
+        super().__init__(parent, cmap_texture_view)
         self._name = cmap
 
     def _set(self, cmap_name: str):

--- a/fastplotlib/graphics/_features/_data.py
+++ b/fastplotlib/graphics/_features/_data.py
@@ -21,9 +21,7 @@ class PointsDataFeature(GraphicFeatureIndexable):
 
     def __init__(self, parent, data: Any, collection_index: int = None):
         data = self._fix_data(data, parent)
-        super(PointsDataFeature, self).__init__(
-            parent, data, collection_index=collection_index
-        )
+        super().__init__(parent, data, collection_index=collection_index)
 
     @property
     def buffer(self) -> pygfx.Buffer:
@@ -117,7 +115,7 @@ class ImageDataFeature(GraphicFeatureIndexable):
                 "``[x_dim, y_dim]`` or ``[x_dim, y_dim, rgb]``"
             )
 
-        super(ImageDataFeature, self).__init__(parent, data)
+        super().__init__(parent, data)
 
     @property
     def buffer(self) -> pygfx.Texture:

--- a/fastplotlib/graphics/_features/_deleted.py
+++ b/fastplotlib/graphics/_features/_deleted.py
@@ -16,7 +16,7 @@ class Deleted(GraphicFeature):
     """
 
     def __init__(self, parent, value: bool):
-        super(Deleted, self).__init__(parent, value)
+        super().__init__(parent, value)
 
     def _set(self, value: bool):
         value = self._parse_set_value(value)

--- a/fastplotlib/graphics/_features/_present.py
+++ b/fastplotlib/graphics/_features/_present.py
@@ -23,7 +23,7 @@ class PresentFeature(GraphicFeature):
 
     def __init__(self, parent, present: bool = True, collection_index: int = False):
         self._scene = None
-        super(PresentFeature, self).__init__(parent, present, collection_index)
+        super().__init__(parent, present, collection_index)
 
     def _set(self, present: bool):
         present = self._parse_set_value(present)

--- a/fastplotlib/graphics/_features/_selection_features.py
+++ b/fastplotlib/graphics/_features/_selection_features.py
@@ -27,7 +27,7 @@ class LinearSelectionFeature(GraphicFeature):
     """
 
     def __init__(self, parent, axis: str, value: float, limits: Tuple[int, int]):
-        super(LinearSelectionFeature, self).__init__(parent, data=value)
+        super().__init__(parent, data=value)
 
         self._axis = axis
         self._limits = limits
@@ -99,7 +99,7 @@ class LinearRegionSelectionFeature(GraphicFeature):
     def __init__(
         self, parent, selection: Tuple[int, int], axis: str, limits: Tuple[int, int]
     ):
-        super(LinearRegionSelectionFeature, self).__init__(parent, data=selection)
+        super().__init__(parent, data=selection)
 
         self._axis = axis
         self._limits = limits

--- a/fastplotlib/graphics/_features/_sizes.py
+++ b/fastplotlib/graphics/_features/_sizes.py
@@ -21,9 +21,7 @@ class PointsSizesFeature(GraphicFeatureIndexable):
 
     def __init__(self, parent, sizes: Any, collection_index: int = None):
         sizes = self._fix_sizes(sizes, parent)
-        super(PointsSizesFeature, self).__init__(
-            parent, sizes, collection_index=collection_index
-        )
+        super().__init__(parent, sizes, collection_index=collection_index)
 
     @property
     def buffer(self) -> pygfx.Buffer:

--- a/fastplotlib/graphics/_features/_thickness.py
+++ b/fastplotlib/graphics/_features/_thickness.py
@@ -19,7 +19,7 @@ class ThicknessFeature(GraphicFeature):
 
     def __init__(self, parent, thickness: float):
         self._scene = None
-        super(ThicknessFeature, self).__init__(parent, thickness)
+        super().__init__(parent, thickness)
 
     def _set(self, value: float):
         value = self._parse_set_value(value)

--- a/fastplotlib/graphics/histogram.py
+++ b/fastplotlib/graphics/histogram.py
@@ -10,7 +10,7 @@ from ._base import Graphic
 
 class _HistogramBin(pygfx.Mesh):
     def __int__(self, *args, **kwargs):
-        super(_HistogramBin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.bin_center: float = None
         self.frequency: Union[int, float] = None
 
@@ -93,9 +93,7 @@ class HistogramGraphic(Graphic):
 
         data = np.vstack([x_positions_bins, self.hist])
 
-        super(HistogramGraphic, self).__init__(
-            data=data, colors=colors, n_colors=n_bins, **kwargs
-        )
+        super().__init__(data=data, colors=colors, n_colors=n_bins, **kwargs)
 
         self._world_object: pygfx.Group = pygfx.Group()
 

--- a/fastplotlib/graphics/line.py
+++ b/fastplotlib/graphics/line.py
@@ -102,7 +102,7 @@ class LineGraphic(Graphic, Interaction):
             self, self.colors(), cmap_name=cmap, cmap_values=cmap_values
         )
 
-        super(LineGraphic, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         if thickness < 1.1:
             material = pygfx.LineThinMaterial

--- a/fastplotlib/graphics/line_collection.py
+++ b/fastplotlib/graphics/line_collection.py
@@ -87,7 +87,7 @@ class LineCollection(GraphicCollection, Interaction):
 
         """
 
-        super(LineCollection, self).__init__(name)
+        super().__init__(name)
 
         if not isinstance(z_position, float) and z_position is not None:
             if len(data) != len(z_position):
@@ -544,7 +544,7 @@ class LineStack(LineCollection):
         See :class:`LineGraphic` details on the features.
 
         """
-        super(LineStack, self).__init__(
+        super().__init__(
             data=data,
             z_position=z_position,
             thickness=thickness,

--- a/fastplotlib/graphics/scatter.py
+++ b/fastplotlib/graphics/scatter.py
@@ -87,7 +87,7 @@ class ScatterGraphic(Graphic):
         )
 
         self.sizes = PointsSizesFeature(self, sizes)
-        super(ScatterGraphic, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         world_object = pygfx.Points(
             pygfx.Geometry(

--- a/fastplotlib/graphics/selectors/_rectangle_region.py
+++ b/fastplotlib/graphics/selectors/_rectangle_region.py
@@ -28,7 +28,7 @@ class RectangleBoundsFeature(GraphicFeature):
     def __init__(
         self, parent, bounds: Tuple[int, int], axis: str, limits: Tuple[int, int]
     ):
-        super(RectangleBoundsFeature, self).__init__(parent, data=bounds)
+        super().__init__(parent, data=bounds)
 
         self._axis = axis
         self.limits = limits

--- a/fastplotlib/graphics/text.py
+++ b/fastplotlib/graphics/text.py
@@ -55,7 +55,7 @@ class TextGraphic(Graphic):
             * Vertical values: "top", "middle", "baseline", "bottom"
             * Horizontal values: "left", "center", "right"
         """
-        super(TextGraphic, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self._text = text
 

--- a/fastplotlib/layouts/_plot.py
+++ b/fastplotlib/layouts/_plot.py
@@ -45,7 +45,7 @@ class Plot(Subplot, Frame, RecordMixin):
             passed to Subplot, for example ``name``
 
         """
-        super(Plot, self).__init__(
+        super().__init__(
             parent=None,
             position=(0, 0),
             parent_dims=(1, 1),
@@ -62,7 +62,7 @@ class Plot(Subplot, Frame, RecordMixin):
 
     def render(self):
         """performs a single render of the plot, not for the user"""
-        super(Plot, self).render()
+        super().render()
 
         self.renderer.flush()
         self.canvas.request_draw()

--- a/fastplotlib/layouts/_subplot.py
+++ b/fastplotlib/layouts/_subplot.py
@@ -214,7 +214,7 @@ class Dock(PlotArea):
 
         self._size = size
 
-        super(Dock, self).__init__(
+        super().__init__(
             parent=parent,
             position=position,
             camera=pygfx.OrthographicCamera(),
@@ -349,4 +349,4 @@ class Dock(PlotArea):
         if self.size == 0:
             return
 
-        super(Dock, self).render()
+        super().render()


### PR DESCRIPTION
These caught my eye in my earlier review. Simple fix that makes the code a bit simplere / easier to read, but possibly also avoids bugs.

----

Context:

```py
class Foo:    
    def __init__(self):
        print("init Foo")

class Bar(Foo):
    def __init__(self):
        super().__init__()
        print("init Bar")

class Spam(Bar):
    def __init__(self):
        super().__init__()
        print("init Spam")

Spam()
```

Produces:
```
init Foo
init Bar
init Spam
```

Replacing the `super()` in `Spam`  with `super(Spam, self).__init__()` produces the same result.
But if it is replaced with `super(Foo, self).__init__()`, it produces:
```
init Foo
init Spam
```

