### PR TITLE
env var required for nb test funcs to run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
         PYGFX_EXPECT_LAVAPIPE: true
       run: |
         pytest -v examples
-        pytest --nbmake examples/notebooks/
+        FASTPLOTLIB_NB_TESTS=1 pytest --nbmake examples/notebooks/
     - uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:

--- a/examples/notebooks/nb_test_utils.py
+++ b/examples/notebooks/nb_test_utils.py
@@ -21,7 +21,19 @@ os.makedirs(DIFFS_DIR, exist_ok=True)
 FAILURES = list()
 
 
+def _run_tests():
+    if "FASTPLOTLIB_NB_TESTS" not in os.environ.keys():
+        return False
+
+    if os.environ["FASTPLOTLIB_NB_TESTS"] == "1":
+        return True
+
+    return False
+
+
 def plot_test(name, plot: Union[Plot, GridPlot]):
+    if not _run_tests():
+        return
     snapshot = plot.canvas.snapshot()
 
     if "REGENERATE_SCREENSHOTS" in os.environ.keys():
@@ -81,6 +93,9 @@ def update_diffs(name, is_similar, img, ground_truth):
 
 
 def notebook_finished():
+    if not _run_tests():
+        return
+
     if len(FAILURES) > 0:
         raise AssertionError(
             f"Failures for plots:\n{FAILURES}"


### PR DESCRIPTION
closes #438

this prevents exceptions from being raised in the example notebooks which have testing cells. They are marked as "for testing, ignore" but with this PR the functions just return immediately anyways if the user has run them. The test functions now require the env var `FASTPLOTLIB_NB_TESTS="1"` to run.
