### PR TITLE
add marker, edge_color, edge_with to `ScatterGraphic`

### DIFF
--- a/docs/source/api/graphics/ScatterGraphic.rst
+++ b/docs/source/api/graphics/ScatterGraphic.rst
@@ -25,7 +25,10 @@ Properties
     ScatterGraphic.colors
     ScatterGraphic.data
     ScatterGraphic.deleted
+    ScatterGraphic.edge_color
+    ScatterGraphic.edge_width
     ScatterGraphic.event_handlers
+    ScatterGraphic.marker
     ScatterGraphic.name
     ScatterGraphic.offset
     ScatterGraphic.rotation

--- a/examples/desktop/scatter/scatter_marker.py
+++ b/examples/desktop/scatter/scatter_marker.py
@@ -1,0 +1,56 @@
+"""
+Scatter Plot Markers
+====================
+
+Example showing scatter plot using different markers
+"""
+
+# test_example = true
+# sphinx_gallery_pygfx_docs = 'screenshot'
+
+import fastplotlib as fpl
+import pygfx
+import numpy as np
+from sklearn.cluster import AgglomerativeClustering
+from sklearn import datasets
+
+
+iris = datasets.load_iris()
+data = iris["data"]
+targets = iris["target"]
+
+agg = AgglomerativeClustering(n_clusters=3)
+agg.fit_predict(data)
+
+figure = fpl.Figure()
+
+# markers to denote the real label
+markers = ["circle", "cross", "square"]
+
+
+# colors to denote the clustering results
+tab10 = fpl.utils.make_colors(3, "tab10")
+label_colors = {i: pygfx.Color(tab10[i]).hex for i in range(3)}
+# makes a list of hex strings by mapping the labels using the above dict
+colors = np.fromiter(map(label_colors.get, agg.labels_), dtype="<U7")
+
+for marker, target in zip(markers, np.unique(targets)):
+    figure[0, 0].add_scatter(
+        data=data[targets == target, :-1].astype(np.float32),
+        sizes=15,
+        alpha=0.5,
+        colors=colors[targets == target],
+        marker=marker,
+    )
+
+figure.show()
+
+figure.canvas.set_logical_size(700, 560)
+
+figure[0, 0].auto_scale()
+
+# NOTE: `if __name__ == "__main__"` is NOT how to use fastplotlib interactively
+# please see our docs for using fastplotlib interactively in ipython and jupyter
+if __name__ == "__main__":
+    print(__doc__)
+    fpl.run()

--- a/fastplotlib/graphics/_features/__init__.py
+++ b/fastplotlib/graphics/_features/__init__.py
@@ -7,6 +7,13 @@ from ._positions_graphics import (
     PointsSizesFeature,
     VertexCmap,
 )
+
+from ._scatter import (
+    ScatterMarker,
+    ScatterEdgeColor,
+    ScatterEdgeWidth,
+)
+
 from ._image import (
     TextureArray,
     ImageCmap,

--- a/fastplotlib/graphics/_features/_positions_graphics.py
+++ b/fastplotlib/graphics/_features/_positions_graphics.py
@@ -1,4 +1,8 @@
-from typing import Any, List
+"""
+features shared by LineGraphic and ScatterGraphic
+"""
+
+from typing import Any
 
 import numpy as np
 import pygfx

--- a/fastplotlib/graphics/_features/_scatter.py
+++ b/fastplotlib/graphics/_features/_scatter.py
@@ -1,0 +1,66 @@
+"""
+features unique to ScatterGraphic
+"""
+
+import numpy as np
+import pygfx
+
+from ._base import (
+    GraphicFeature,
+    FeatureEvent,
+)
+
+
+class ScatterMarker(GraphicFeature):
+    def __init__(self, value: str):
+        self._value = value
+        super().__init__()
+
+    @property
+    def value(self) -> str:
+        return self._value
+
+    def set_value(self, graphic, value: str):
+        graphic.world_object.material.marker = value
+        self._value = value
+
+        event = FeatureEvent(type="marker", info={"value": value})
+        self._call_event_handlers(event)
+
+
+class ScatterEdgeColor(GraphicFeature):
+    def __init__(
+        self, value: str | np.ndarray | tuple | list | pygfx.Color, alpha: float = 1.0
+    ):
+        v = (*tuple(pygfx.Color(value))[:-1], alpha)  # apply alpha
+        self._value = pygfx.Color(v)
+        super().__init__()
+
+    @property
+    def value(self) -> pygfx.Color:
+        return self._value
+
+    def set_value(self, graphic, value: str | np.ndarray | tuple | list | pygfx.Color):
+        value = pygfx.Color(value)
+        graphic.world_object.material.edge_color = value
+        self._value = value
+
+        event = FeatureEvent(type="edge_color", info={"value": value})
+        self._call_event_handlers(event)
+
+
+class ScatterEdgeWidth(GraphicFeature):
+    def __init__(self, value: float):
+        self._value = float(value)
+        super().__init__()
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    def set_value(self, graphic, value: float):
+        graphic.world_object.material.edge_width = float(value)
+        self._value = value
+
+        event = FeatureEvent(type="edge_width", info={"value": value})
+        self._call_event_handlers(event)

--- a/fastplotlib/graphics/scatter.py
+++ b/fastplotlib/graphics/scatter.py
@@ -4,11 +4,11 @@ import numpy as np
 import pygfx
 
 from ._positions_base import PositionsGraphic
-from ._features import PointsSizesFeature, UniformSize
+from ._features import PointsSizesFeature, UniformSize, ScatterMarker, ScatterEdgeColor, ScatterEdgeWidth
 
 
 class ScatterGraphic(PositionsGraphic):
-    _features = {"data", "sizes", "colors", "cmap"}
+    _features = {"data", "sizes", "colors", "cmap", "marker", "edge_width", "edge_color"}
 
     def __init__(
         self,
@@ -18,9 +18,12 @@ class ScatterGraphic(PositionsGraphic):
         alpha: float = 1.0,
         cmap: str = None,
         cmap_transform: np.ndarray = None,
-        isolated_buffer: bool = True,
-        sizes: float | np.ndarray | Iterable[float] = 1,
+        sizes: float | np.ndarray | Iterable[float] = 5,
         uniform_size: bool = False,
+        marker: str = "circle",
+        edge_color: str | np.ndarray | tuple[float] | list[float] = "black",
+        edge_width: float = 1.0,
+        isolated_buffer: bool = True,
         **kwargs,
     ):
         """
@@ -49,16 +52,61 @@ class ScatterGraphic(PositionsGraphic):
         cmap_transform: 1D array-like or list of numerical values, optional
             if provided, these values are used to map the colors from the cmap
 
-        isolated_buffer: bool, default True
-            whether the buffers should be isolated from the user input array.
-            Generally always ``True``, ``False`` is for rare advanced use.
-
         sizes: float or iterable of float, optional, default 1.0
             size of the scatter points
 
         uniform_size: bool, default False
             if True, uses a uniform buffer for the scatter point sizes,
             basically saves GPU VRAM when all scatter points are the same size
+
+        marker: str, default "circle"
+            shape of the markers
+
+            Valid inputs are the following strings or unicode characters and emojis::
+
+                "o": "circle",
+                "s": "square",
+                "D": "diamond",
+                "+": "plus",
+                "x": "cross",
+                "^": "triangle_up",
+                "<": "triangle_left",
+                ">": "triangle_right",
+                "v": "triangle_down",
+
+                # Unicode
+                "●": "circle",
+                "○": "ring",
+                "■": "square",
+                "♦": "diamond",
+                "♥": "heart",
+                "♠": "spade",
+                "♣": "club",
+                "✳": "asterix",
+                "▲": "triangle_up",
+                "▼": "triangle_down",
+                "◀": "triangle_left",
+                "▶": "triangle_right",
+
+                # Emojis (these may look like their plaintext variants in your editor)
+                "❤️": "heart",
+                "♠️": "spade",
+                "♣️": "club",
+                "♦️": "diamond",
+                "💎": "diamond",
+                "💍": "ring",
+                "✳️": "asterix",
+                "📍": "pin",
+
+        edge_color: str, array, or iterable, default "black"
+            color of the scatter point edges, accepts any type that pygfx.Color can parse
+
+        edge_width: float, default 1.0
+            width of the scatter point edges
+
+        isolated_buffer: bool, default True
+            whether the buffers should be isolated from the user input array.
+            Generally always ``True``, ``False`` is for rare advanced use.
 
         kwargs
             passed to Graphic
@@ -79,7 +127,20 @@ class ScatterGraphic(PositionsGraphic):
         n_datapoints = self.data.value.shape[0]
 
         geo_kwargs = {"positions": self._data.buffer}
-        material_kwargs = {"pick_write": True}
+        material_kwargs = {
+            "pick_write": True,
+        }
+
+        self._marker = ScatterMarker(marker)
+        self._edge_color = ScatterEdgeColor(edge_color)
+        self._edge_width = ScatterEdgeWidth(edge_width)
+
+        material_kwargs = {
+            **material_kwargs,
+            "marker": marker,
+            "edge_color": edge_color,
+            "edge_width": edge_width,
+        }
 
         if uniform_color:
             material_kwargs["color_mode"] = "uniform"
@@ -99,7 +160,7 @@ class ScatterGraphic(PositionsGraphic):
 
         world_object = pygfx.Points(
             pygfx.Geometry(**geo_kwargs),
-            material=pygfx.PointsMaterial(**material_kwargs),
+            material=pygfx.PointsMarkerMaterial(**material_kwargs),
         )
 
         self._set_world_object(world_object)
@@ -120,3 +181,29 @@ class ScatterGraphic(PositionsGraphic):
 
         elif isinstance(self._sizes, UniformSize):
             self._sizes.set_value(self, value)
+
+    @property
+    def marker(self) -> str:
+        return self._marker.value
+
+    @marker.setter
+    def marker(self, value):
+        self._marker.set_value(self, value)
+
+    @property
+    def edge_color(self) -> pygfx.Color:
+        if self._edge_color is not None:
+            return self._edge_color.value
+
+    @edge_color.setter
+    def edge_color(self, value: str | np.ndarray | tuple[float] | list[float]):
+        self._edge_color.set_value(self, value)
+
+    @property
+    def edge_width(self) -> float:
+        if self._edge_width is not None:
+            return self._edge_width.value
+
+    @edge_width.setter
+    def edge_width(self, value: float):
+        self._edge_width.set_value(self, value)

--- a/fastplotlib/layouts/_graphic_methods_mixin.py
+++ b/fastplotlib/layouts/_graphic_methods_mixin.py
@@ -345,9 +345,12 @@ class GraphicMethodsMixin:
         alpha: float = 1.0,
         cmap: str = None,
         cmap_transform: numpy.ndarray = None,
-        isolated_buffer: bool = True,
-        sizes: Union[float, numpy.ndarray, Iterable[float]] = 1,
+        sizes: Union[float, numpy.ndarray, Iterable[float]] = 5,
         uniform_size: bool = False,
+        marker: str = "circle",
+        edge_color: str | numpy.ndarray | tuple[float] | list[float] = "black",
+        edge_width: float = 1.0,
+        isolated_buffer: bool = True,
         **kwargs
     ) -> ScatterGraphic:
         """
@@ -377,16 +380,61 @@ class GraphicMethodsMixin:
         cmap_transform: 1D array-like or list of numerical values, optional
             if provided, these values are used to map the colors from the cmap
 
-        isolated_buffer: bool, default True
-            whether the buffers should be isolated from the user input array.
-            Generally always ``True``, ``False`` is for rare advanced use.
-
         sizes: float or iterable of float, optional, default 1.0
             size of the scatter points
 
         uniform_size: bool, default False
             if True, uses a uniform buffer for the scatter point sizes,
             basically saves GPU VRAM when all scatter points are the same size
+
+        marker: str, default "circle"
+            shape of the markers
+
+            Valid inputs are the following strings or unicode characters and emojis::
+
+                "o": "circle",
+                "s": "square",
+                "D": "diamond",
+                "+": "plus",
+                "x": "cross",
+                "^": "triangle_up",
+                "<": "triangle_left",
+                ">": "triangle_right",
+                "v": "triangle_down",
+
+                # Unicode
+                "●": "circle",
+                "○": "ring",
+                "■": "square",
+                "♦": "diamond",
+                "♥": "heart",
+                "♠": "spade",
+                "♣": "club",
+                "✳": "asterix",
+                "▲": "triangle_up",
+                "▼": "triangle_down",
+                "◀": "triangle_left",
+                "▶": "triangle_right",
+
+                # Emojis (these may look like their plaintext variants in your editor)
+                "❤️": "heart",
+                "♠️": "spade",
+                "♣️": "club",
+                "♦️": "diamond",
+                "💎": "diamond",
+                "💍": "ring",
+                "✳️": "asterix",
+                "📍": "pin",
+
+        edge_color: str, array, or iterable, default "black"
+            color of the scatter point edges, accepts any type that pygfx.Color can parse
+
+        edge_width: float, default 1.0
+            width of the scatter point edges
+
+        isolated_buffer: bool, default True
+            whether the buffers should be isolated from the user input array.
+            Generally always ``True``, ``False`` is for rare advanced use.
 
         kwargs
             passed to Graphic
@@ -401,9 +449,12 @@ class GraphicMethodsMixin:
             alpha,
             cmap,
             cmap_transform,
-            isolated_buffer,
             sizes,
             uniform_size,
+            marker,
+            edge_color,
+            edge_width,
+            isolated_buffer,
             **kwargs
         )
 


### PR DESCRIPTION
WIP, still need to do tests and think about how exactly to implement markers

@almarklein do you think it could be possible and make sense to allow markers to be set per-vertex for `pygfx.Points`? It would make it easier to create visualization with a mix of both, and even easier to change markers per-vertex.

For example, with how I've currently implemented it a `ScatterGraphic` is required per-marker type for a visualization:

```python
import fastplotlib as fpl
import pygfx
import numpy as np
from sklearn.cluster import AgglomerativeClustering
from sklearn import datasets


iris = datasets.load_iris()
data = iris["data"]
targets = iris["target"]

agg = AgglomerativeClustering(n_clusters=3)
agg.fit_predict(data)

figure = fpl.Figure()

# markers to denote the real label
markers = ["circle", "cross", "square"]


# colors to denote the clustering results
tab10 = fpl.utils.make_colors(3, "tab10")
label_colors = {i: pygfx.Color(tab10[i]).hex for i in range(3)}
# makes a list of hex strings by mapping the labels using the above dict
colors = np.fromiter(map(label_colors.get, agg.labels_), dtype="<U7")

for marker, target in zip(markers, np.unique(targets)):
    figure[0, 0].add_scatter(
        data=data[targets == target, :-1].astype(np.float32),
        sizes=15,
        alpha=0.5,
        colors=colors[targets == target],
        marker=marker,
    )

figure.show()
```

![image](https://github.com/fastplotlib/fastplotlib/assets/9403332/17087f28-e15c-436a-94d2-9e0ebe1163ab)

If not no worries, I think a workaround is to make `ScatterGraphic` manage a `pygfx.Group`, and allow `markers` to be passed as an iterable of `str` markers, and then make the materials based on the passed markers. The tricky part is changing the materials any time a user changes the markers. :thinking: 
