### PR TITLE
Basic axes

### DIFF
--- a/fastplotlib/layouts/_axes.py
+++ b/fastplotlib/layouts/_axes.py
@@ -1,0 +1,296 @@
+import pygfx
+
+
+# very thin subclass that just adds GridMaterial properties to this world object for easier user control
+class Grid(pygfx.Grid):
+    @property
+    def major_step(self):
+        """The step distance between the major grid lines."""
+        return self.material.major_step
+
+    @major_step.setter
+    def major_step(self, step):
+        self.material.major_step = step
+
+    @property
+    def minor_step(self):
+        """The step distance between the minor grid lines."""
+        return self.material.minor_step
+
+    @minor_step.setter
+    def minor_step(self, step):
+        self.material.minor_step = step
+
+    @property
+    def axis_thickness(self):
+        """The thickness of the axis lines."""
+        return self.material.axis_thickness
+
+    @axis_thickness.setter
+    def axis_thickness(self, thickness):
+        self.material.axis_thickness = thickness
+
+    @property
+    def major_thickness(self):
+        """The thickness of the major grid lines."""
+        return self.material.major_thickness
+
+    @major_thickness.setter
+    def major_thickness(self, thickness):
+        self.material.major_thickness = thickness
+
+    @property
+    def minor_thickness(self):
+        """The thickness of the minor grid lines."""
+        return self.material.minor_thickness
+
+    @minor_thickness.setter
+    def minor_thickness(self, thickness):
+        self.material.minor_thickness = thickness
+
+    @property
+    def thickness_space(self):
+        """The coordinate space in which the thicknesses are expressed.
+
+        See :obj:`pygfx.utils.enums.CoordSpace`:
+        """
+        return self.material.thickness_space
+
+    @thickness_space.setter
+    def thickness_space(self, value):
+        self.material.thickness_space = value
+
+    @property
+    def axis_color(self):
+        """The color of the axis lines."""
+        return self.material.axis_color
+
+    @axis_color.setter
+    def axis_color(self, color):
+        self.material.axis_color = color
+
+    @property
+    def major_color(self):
+        """The color of the major grid lines."""
+        return self.material.major_color
+
+    @major_color.setter
+    def major_color(self, color):
+        self.material.major_color = color
+
+    @property
+    def minor_color(self):
+        """The color of the minor grid lines."""
+        return self.material.minor_color
+
+    @minor_color.setter
+    def minor_color(self, color):
+        self.material.minor_color = color
+
+    @property
+    def infinite(self):
+        """Whether the grid is infinite.
+
+        If not infinite, the grid is 1x1 in world space, scaled, rotated, and
+        positioned with the object's transform.
+
+        (Infinite grids are not actually infinite. Rather they move along with
+        the camera, and are sized based on the distance between the camera and
+        the grid.)
+        """
+        return self.material.infinite
+
+    @infinite.setter
+    def infinite(self, value):
+        self.material.infinite = value
+
+
+class Axes:
+    def __init__(
+            self,
+            plot_area,
+            follow: bool = True,
+            x_kwargs: dict = None,
+            y_kwargs: dict = None,
+            z_kwargs: dict = None,
+            grid_kwargs: dict = None,
+            auto_grid: bool = True,
+    ):
+        self._plot_area = plot_area
+
+        if x_kwargs is None:
+            x_kwargs = dict()
+
+        if y_kwargs is None:
+            y_kwargs = dict()
+
+        if z_kwargs is None:
+            z_kwargs = dict()
+
+        x_kwargs = {
+            "tick_side": "right",
+            **x_kwargs,
+        }
+
+        y_kwargs = {
+            "tick_side": "left",
+            **y_kwargs
+        }
+
+        # z_kwargs = {
+        #     "tick_side": "left",
+        #     **z_kwargs,
+        # }
+
+        self._x = pygfx.Ruler(**x_kwargs)
+        self._y = pygfx.Ruler(**y_kwargs)
+        # self._z = pygfx.Ruler(**z_kwargs)
+
+        # *MUST* instantiate some start and end positions for the rulers else kernel crashes immediately
+        # probably a WGPU rust panic
+        self.x.start_pos = self._plot_area.camera.world.x - self._plot_area.camera.width / 2, 0, -1000
+        self.x.end_pos = self._plot_area.camera.world.x + self._plot_area.camera.width / 2, 0, -1000
+        self.x.start_value = self.x.start_pos[0]
+        statsx = self.x.update(self._plot_area.camera, self._plot_area.canvas.get_logical_size())
+
+        self.y.start_pos = 0, self._plot_area.camera.world.y - self._plot_area.camera.height / 2, -1000
+        self.y.end_pos = 0, self._plot_area.camera.world.y + self._plot_area.camera.height / 2, -1000
+        self.y.start_value = self.y.start_pos[1]
+        statsy = self.y.update(self._plot_area.camera, self._plot_area.canvas.get_logical_size())
+
+        self._world_object = pygfx.Group()
+        self.world_object.add(
+            self.x,
+            self.y,
+            # self._z,
+        )
+
+        if grid_kwargs is None:
+            grid_kwargs = dict()
+
+        grid_kwargs = {
+            "major_step": 10,
+            "minor_step": 1,
+            "thickness_space": "screen",
+            "major_thickness": 2,
+            "minor_thickness": 0.5,
+            "infinite": True,
+            **grid_kwargs
+        }
+
+        self._grids = dict()
+
+        for plane in ["xy", "xz", "yz"]:
+            self._grids[plane] = Grid(
+                geometry=None,
+                material=pygfx.GridMaterial(**grid_kwargs),
+                orientation=plane,
+            )
+
+            self._grids[plane].local.z = -1001
+
+            self.world_object.add(self._grids[plane])
+
+        major_step_x, major_step_y = statsx["tick_step"], statsy["tick_step"]
+
+        if "xy" in self.grids.keys():
+            self.grids["xy"].material.major_step = major_step_x, major_step_y
+            self.grids["xy"].material.minor_step = 0.2 * major_step_x, 0.2 * major_step_y
+
+        self._follow = follow
+        self._auto_grid = auto_grid
+
+    @property
+    def world_object(self) -> pygfx.WorldObject:
+        return self._world_object
+
+    @property
+    def x(self) -> pygfx.Ruler:
+        """x axis ruler"""
+        return self._x
+
+    @property
+    def y(self) -> pygfx.Ruler:
+        """y axis ruler"""
+        return self._y
+    #
+    # @property
+    # def z(self) -> pygfx.Ruler:
+    #     return self._z
+    #
+    @property
+    def grids(self) -> dict[str, pygfx.Grid]:
+        """grids for each plane if present: 'xy', 'xz', 'yz'"""
+        return self._grids
+
+    @property
+    def auto_grid(self) -> bool:
+        return self._auto_grid
+
+    @auto_grid.setter
+    def auto_grid(self, value: bool):
+        self._auto_grid = value
+
+    @property
+    def visible(self) -> bool:
+        return self._world_object.visible
+
+    @visible.setter
+    def visible(self, value: bool):
+        self._world_object.visible = value
+
+    @property
+    def follow(self) -> bool:
+        return self._follow
+
+    @follow.setter
+    def follow(self, value: bool):
+        if not isinstance(value, bool):
+            raise TypeError
+        self._follow = value
+
+    def animate(self):
+        # TODO: figure out z
+        rect = self._plot_area.get_rect()
+
+        # get range of screen space
+        xmin, xmax = rect[0], rect[2]
+        ymin, ymax = rect[3], rect[1]
+
+        world_xmin, world_ymin, _ = self._plot_area.map_screen_to_world((xmin, ymin))
+        world_xmax, world_ymax, _ = self._plot_area.map_screen_to_world((xmax, ymax))
+
+        if self.follow:
+            # place the ruler close to the left and bottom edges of the viewport
+            xscreen_10, yscreen_10 = 0.1 * rect[2], 0.9 * rect[3]
+            world_x_10, world_y_10, _ = self._plot_area.map_screen_to_world((xscreen_10, yscreen_10))
+
+        else:
+            # axes intersect at the origin
+            world_x_10, world_y_10 = 0, 0
+
+        # swap min and max for each dimension if necessary
+        if self._plot_area.camera.local.scale_y < 0:
+            world_ymin, world_ymax = world_ymax, world_ymin
+
+        if self._plot_area.camera.local.scale_x < 0:
+            world_xmin, world_xmax = world_xmax, world_xmin
+
+        self.x.start_pos = world_xmin, world_y_10, -1000
+        self.x.end_pos = world_xmax, world_y_10, -1000
+
+        self.x.start_value = self.x.start_pos[0]
+        statsx = self.x.update(self._plot_area.camera, self._plot_area.canvas.get_logical_size())
+
+        self.y.start_pos = world_x_10, world_ymin, -1000
+        self.y.end_pos = world_x_10, world_ymax, -1000
+
+        self.y.start_value = self.y.start_pos[1]
+        statsy = self.y.update(self._plot_area.camera, self._plot_area.canvas.get_logical_size())
+
+        if self.auto_grid:
+            major_step_x, major_step_y = statsx["tick_step"], statsy["tick_step"]
+
+            if "xy" in self.grids.keys():
+                self.grids["xy"].material.major_step = major_step_x, major_step_y
+                self.grids["xy"].material.minor_step = 0.2 * major_step_x, 0.2 * major_step_y

--- a/fastplotlib/layouts/_subplot.py
+++ b/fastplotlib/layouts/_subplot.py
@@ -10,6 +10,7 @@ from ..graphics import TextGraphic
 from ._utils import make_canvas_and_renderer, create_camera, create_controller
 from ._plot_area import PlotArea
 from ._graphic_methods_mixin import GraphicMethodsMixin
+from ._axes import Axes
 
 
 class Subplot(PlotArea, GraphicMethodsMixin):
@@ -88,12 +89,6 @@ class Subplot(PlotArea, GraphicMethodsMixin):
 
         self.spacing = 2
 
-        self._axes: pygfx.AxesHelper = pygfx.AxesHelper(size=100)
-        for arrow in self._axes.children:
-            self._axes.remove(arrow)
-
-        self._grid: pygfx.GridHelper = pygfx.GridHelper(size=100, thickness=1)
-
         self._title_graphic: TextGraphic = None
 
         super(Subplot, self).__init__(
@@ -115,6 +110,10 @@ class Subplot(PlotArea, GraphicMethodsMixin):
 
         if self.name is not None:
             self.set_title(self.name)
+
+        self.axes = Axes(self)
+        self.scene.add(self.axes.world_object)
+        self.add_animations(self.axes.animate)
 
     @property
     def name(self) -> str:
@@ -186,20 +185,6 @@ class Subplot(PlotArea, GraphicMethodsMixin):
             rect = rect + dv.get_parent_rect_adjust()
 
         return rect
-
-    def set_axes_visibility(self, visible: bool):
-        """Toggles axes visibility."""
-        if visible:
-            self.scene.add(self._axes)
-        else:
-            self.scene.remove(self._axes)
-
-    def set_grid_visibility(self, visible: bool):
-        """Toggles grid visibility."""
-        if visible:
-            self.scene.add(self._grid)
-        else:
-            self.scene.remove(self._grid)
 
 
 class Dock(PlotArea):


### PR DESCRIPTION
Started prototyping axes. A lot of this is based on the pygfx ruler example. @almarklein would be great to get your input on this, this is just a prototype so I'm more than happy if you had other ideas on how to do this! I was too excited to protype this :smile: 

Summary:

### Grid class
subclass `pygfx.Grid` to give it properties from the `GridMaterial` so the user can for example do `subplot.axes.grid["xy"].major_step` instead of ``subplot.axes.grid["xy"].material.major_step`

### Axes class

The main properties are:
  - `x`, `y`, `z` - `pygfx.Ruler` instance for each dimension
  - `grid` - dict containing the `Grid` instance for each plane, "xy", "xz", "yz" 
  - `follow` - whether or not the axes follow the camera in the bottom-left corner during pan

Has one method: `animate`, which based on the pygfx ruler example and sets the ruler start and end positions, and updates them. Main differences from the current pygfx example are:
  - uses inverse projection to find the range of the world space, accounts for camera zoom etc. 
  - the `pygfx.Ruler` start and end points are swapped if the `camera.local.scale_{dim}` is negative. 

`Subplots` auto-make an `Axes` instance. The `animate` function to update the axes are added to the subplot's render functions list.

I also had to slightly modify `PlotArea`. There's a new `pygfx.Group` `PlotArea._graphics_scene` which sequesters all the `WorldObjects` that belong to `Graphics` in the `PlotArea`. This allows us to compute the world bounding box on the actual plot-data-graphics and exclude the selectors. 

`PlotArea._graphics_scene` is added to `PlotArea.scene`, and non-`Graphic` `WorldObjects`, such as legends, the axes, and selector tools, are added directly to `PlotArea.scene`.

Todo:
- [ ] Not working with `camera.fov > 0`, need to figure out why.
- [ ] z axis ruler
- [ ] figure out how to set `PlotArea.auto_scale()` such that the rulers are in the bottom left corner, basically take into account the ruler spacing from the subplot edge so that all the `Graphics` are "contained" within the rulers when `auto_scale()` is used, right now it's wonky with the current auto_scale. I think just reducing the zoom should be sufficient?
- [ ] modify all test screenshots again :upside_down_face: 

https://github.com/fastplotlib/fastplotlib/assets/9403332/dc4ad68e-7aeb-4a9c-9660-24e96e051ede

https://github.com/fastplotlib/fastplotlib/assets/9403332/a1cbb81f-f1c0-43a5-b461-56818c0d8ed9
