### PR TITLE
catchup with pygfx, remove checks for pending uploads from tests

### DIFF
--- a/tests/test_colors_buffer_manager.py
+++ b/tests/test_colors_buffer_manager.py
@@ -8,7 +8,6 @@ import fastplotlib as fpl
 from fastplotlib.graphics._features import VertexColors, FeatureEvent
 from .utils import (
     generate_slice_indices,
-    assert_pending_uploads,
     generate_color_inputs,
     generate_positions_spiral_data,
 )
@@ -61,11 +60,8 @@ def test_int(test_graphic):
         colors = make_colors_buffer()
 
     # TODO: placeholder until I make a testing figure where we draw frames only on call
-    colors.buffer._gfx_pending_uploads.clear()
-
     colors[3] = "r"
     npt.assert_almost_equal(colors[3], [1.0, 0.0, 0.0, 1.0])
-    assert colors.buffer._gfx_pending_uploads[-1] == (3, 1)
 
     if test_graphic:
         # test event
@@ -206,9 +202,6 @@ def test_slice(color_input, slice_method: dict, test_graphic: bool):
     else:
         colors = make_colors_buffer()
 
-    # TODO: placeholder until I make a testing figure where we draw frames only on call
-    colors.buffer._gfx_pending_uploads.clear()
-
     s = slice_method["slice"]
     indices = slice_method["indices"]
     offset = slice_method["offset"]
@@ -237,9 +230,6 @@ def test_slice(color_input, slice_method: dict, test_graphic: bool):
             assert EVENT_RETURN_VALUE.info["user_value"] == color_input
         else:
             npt.assert_almost_equal(EVENT_RETURN_VALUE.info["user_value"], color_input)
-
-    # make sure correct offset and size marked for pending upload
-    assert_pending_uploads(colors.buffer, offset, size)
 
     # check that others are not touched
     others_truth = np.repeat([[1.0, 1.0, 1.0, 1.0]], repeats=len(others), axis=0)

--- a/tests/test_positions_data_buffer_manager.py
+++ b/tests/test_positions_data_buffer_manager.py
@@ -6,7 +6,6 @@ import fastplotlib as fpl
 from fastplotlib.graphics._features import VertexPositions, FeatureEvent
 from .utils import (
     generate_slice_indices,
-    assert_pending_uploads,
     generate_positions_spiral_data,
 )
 
@@ -134,9 +133,6 @@ def test_slice(test_graphic, slice_method: dict, test_axis: str):
     size = slice_method["size"]
     others = slice_method["others"]
 
-    # TODO: placeholder until I make a testing figure where we draw frames only on call
-    points.buffer._gfx_pending_uploads.clear()
-
     match test_axis:
         case "y":
             points[s, 1] = -data[s, 1]
@@ -203,6 +199,3 @@ def test_slice(test_graphic, slice_method: dict, test_axis: str):
                 else:
                     npt.assert_almost_equal(EVENT_RETURN_VALUE.info["key"], s)
                 npt.assert_almost_equal(EVENT_RETURN_VALUE.info["value"], -data[s])
-
-    # make sure correct offset and size marked for pending upload
-    assert_pending_uploads(points.buffer, offset, size)

--- a/tests/test_positions_graphics.py
+++ b/tests/test_positions_graphics.py
@@ -21,7 +21,6 @@ from .utils import (
     generate_color_inputs,
     MULTI_COLORS_TRUTH,
     generate_slice_indices,
-    assert_pending_uploads,
 )
 
 

--- a/tests/test_sizes_buffer_manager.py
+++ b/tests/test_sizes_buffer_manager.py
@@ -3,7 +3,7 @@ from numpy import testing as npt
 import pytest
 
 from fastplotlib.graphics._features import PointsSizesFeature
-from .utils import generate_slice_indices, assert_pending_uploads
+from .utils import generate_slice_indices
 
 
 def generate_data(input_type: str) -> np.ndarray | float:
@@ -52,9 +52,6 @@ def test_slice(slice_method: dict, user_input: str):
 
     sizes = PointsSizesFeature(data, n_datapoints=10)
 
-    # TODO: placeholder until I make a testing figure where we draw frames only on call
-    sizes.buffer._gfx_pending_uploads.clear()
-
     match user_input:
         case "float":
             sizes[s] = 20.0
@@ -71,6 +68,3 @@ def test_slice(slice_method: dict, user_input: str):
             npt.assert_almost_equal(sizes[indices], cosine[s])
             # make sure other sizes not modified
             npt.assert_almost_equal(sizes[others], data[others])
-
-    # make sure correct offset and size marked for pending upload
-    assert_pending_uploads(sizes.buffer, offset, size)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -106,17 +106,6 @@ def generate_slice_indices(kind: int):
     }
 
 
-def assert_pending_uploads(buffer: pygfx.Buffer, offset: int, size: int):
-    upload_offset, upload_size = buffer._gfx_pending_uploads[-1]
-    # sometimes when slicing with step, it  will over-estimate offset
-    # but it overestimates to upload 1 extra point so it's fine
-    assert (upload_offset == offset) or (upload_offset == offset - 1)
-
-    # sometimes when slicing with step, it  will over-estimate size
-    # but it overestimates to upload 1 extra point so it's fine
-    assert (upload_size == size) or (upload_size == size + 1)
-
-
 def generate_positions_spiral_data(inputs: str) -> np.ndarray:
     """
     Generates a spiral/spring


### PR DESCRIPTION
after https://github.com/pygfx/pygfx/pull/795 `Buffer._gfx_pending_uploads` no longer exists. There are new methods `Buffer.update_full()` and `Buffer.update_indices()` which we can make use of instead of us having to check these ourselves.

One purpose of our test was to make sure that indices chosen to be uploaded correctly mapped to a range and it seems like we don't have to worry about this anymore, thanks @almarklein ! :smile: 

We should change our `BufferManagers` to make use of the new buffer upload options! :D 
