### PR TITLE
change basis of axes

### DIFF
--- a/fastplotlib/graphics/_axes.py
+++ b/fastplotlib/graphics/_axes.py
@@ -638,7 +638,7 @@ class Axes:
             self.z.start_pos = world_x_10, world_y_10, world_zmin
             self.z.end_pos = world_x_10, world_y_10, world_zmax
 
-            self.z.start_value = self.z.start_pos[1] - self.offset[2]
+            self.z.start_value = self.z.start_pos[2] - self.offset[2]
             statsz = self.z.update(
                 self._plot_area.camera, self._plot_area.viewport.logical_size
             )

--- a/fastplotlib/graphics/_axes.py
+++ b/fastplotlib/graphics/_axes.py
@@ -6,11 +6,7 @@ from pylinalg import quat_from_vecs, vec_transform_quat
 
 GRID_PLANES = ["xy", "xz", "yz"]
 
-CANONICAL_BAIS = np.array([
-    [1., 0., 0.],
-    [0., 1., 0.],
-    [0., 0., 1.]
-])
+CANONICAL_BAIS = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
 
 # very thin subclass that just adds GridMaterial properties to this world object for easier user control
@@ -259,7 +255,9 @@ class Axes:
         grid_kwargs: dict = None,
         auto_grid: bool = True,
         offset: np.ndarray = np.array([0.0, 0.0, 0.0]),
-        basis: np.ndarray = np.array([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
+        basis: np.ndarray = np.array(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+        ),
     ):
         self._plot_area = plot_area
 


### PR DESCRIPTION
closes #561 

WIP, seems to be ok in 2D, something wonky in 3D. Those blue axes should be pointing out towards the red points. And one ruler is completely MIA

![download](https://github.com/user-attachments/assets/277473c4-cbfc-4852-b368-699d24b9816c)

using [`pylinalg.quat_from_vecs`](https://pylinalg.readthedocs.io/en/latest/reference.html#pylinalg.quat_from_vecs) to create the quaternion to rotate the axes world object.
