### PR TITLE
Fix move to pointer for selectors again

### DIFF
--- a/fastplotlib/graphics/_features/_selection_features.py
+++ b/fastplotlib/graphics/_features/_selection_features.py
@@ -48,7 +48,7 @@ class LinearSelectionFeature(GraphicFeature):
         self._value = value
 
     @property
-    def value(self) -> float:
+    def value(self) -> np.float32:
         """
         selection, data x or y value
         """
@@ -56,7 +56,7 @@ class LinearSelectionFeature(GraphicFeature):
 
     def set_value(self, selector, value: float):
         # clip value between limits
-        value = np.clip(value, self._limits[0], self._limits[1])
+        value = np.clip(value, self._limits[0], self._limits[1], dtype=np.float32)
 
         # set position
         if self._axis == "x":

--- a/fastplotlib/graphics/selectors/_base_selector.py
+++ b/fastplotlib/graphics/selectors/_base_selector.py
@@ -280,7 +280,16 @@ class BaseSelector(Graphic):
         elif self.axis == "y":
             offset = self.offset[1]
 
-        current_pos_world: np.ndarray = self.selection + offset
+        if self.selection.size > 1:
+            # linear region selectors
+            # TODO: get center for rectangle and polygon selectors
+            center = self.selection.mean(axis=0)
+
+        else:
+            # linear selectors
+            center = self.selection
+
+        current_pos_world: np.ndarray = center + offset
 
         world_pos = self._plot_area.map_screen_to_world(ev)
 

--- a/fastplotlib/graphics/selectors/_rectangle.py
+++ b/fastplotlib/graphics/selectors/_rectangle.py
@@ -515,3 +515,6 @@ class RectangleSelector(BaseSelector):
             self._selection.set_value(self, (xmin, xmax, ymin_new, ymax))
         if self._move_info.source == self.edges[3]:
             self._selection.set_value(self, (xmin, xmax, ymin, ymax_new))
+
+    def _move_to_pointer(self, ev):
+        pass


### PR DESCRIPTION
followup from #592

closes #468

This fixes it for `LinearRegionSelector` too. To make it work with `RectangleRegionSelector` we need to take the bbox `selection` and get the center point, and later when we properly implement a `PolygonSelector` we can just take the mean of all vertices but we can do these later.
