### PR TITLE
remove ipywidget code from selectors

### DIFF
--- a/fastplotlib/graphics/selectors/_linear.py
+++ b/fastplotlib/graphics/selectors/_linear.py
@@ -5,16 +5,10 @@ from numbers import Real
 import numpy as np
 import pygfx
 
-from ...utils.gui import IS_JUPYTER
 from .._base import Graphic
 from .._collection_base import GraphicCollection
 from .._features._selection_features import LinearSelectionFeature
 from ._base_selector import BaseSelector
-
-
-if IS_JUPYTER:
-    # If using the jupyter backend, user has jupyter_rfb, and thus also ipywidgets
-    import ipywidgets
 
 
 class LinearSelector(BaseSelector):
@@ -68,18 +62,18 @@ class LinearSelector(BaseSelector):
         name: str = None,
     ):
         """
-        Create a horizontal or vertical line slider that is synced to an ipywidget IntSlider
+        Create a horizontal or vertical line that can be used to select a value along an axis
 
         Parameters
         ----------
         selection: int
-            initial x or y selected position for the slider, in world space
+            initial x or y selected position of the selector, in world space
 
         limits: (int, int)
             (min, max) limits along the x or y axis for the selector, in world space
 
         axis: str, default "x"
-            "x" | "y", the axis which the slider can move along
+            "x" | "y", the axis which the selector can move along
 
         center: float
             center offset of the selector on the orthogonal axis, by default the data mean
@@ -93,13 +87,13 @@ class LinearSelector(BaseSelector):
             arrow key movements, or set the attribute ``arrow_key_events_enabled = True``
 
         thickness: float, default 2.5
-            thickness of the slider
+            thickness of the selector
 
         color: Any, default "w"
-            selection to set the color of the slider
+            selection to set the color of the selector
 
         name: str, optional
-            name of line slider
+            name of line selector
 
         """
         if len(limits) != 2:
@@ -155,14 +149,10 @@ class LinearSelector(BaseSelector):
 
         self._move_info: dict = None
 
-        self._block_ipywidget_call = False
-
-        self._handled_widgets = list()
-
         if axis == "x":
-            offset = (parent.offset[0], center + parent.offset[1], 0)
+            offset = (parent.offset[0], center, 0)
         elif axis == "y":
-            offset = (center + parent.offset[0], parent.offset[1], 0)
+            offset = (center, parent.offset[1], 0)
 
         # init base selector
         BaseSelector.__init__(
@@ -187,149 +177,21 @@ class LinearSelector(BaseSelector):
         else:
             self._selection.set_value(self, selection)
 
-        # update any ipywidgets
-        self.add_event_handler(self._update_ipywidgets, "selection")
-
-    def _setup_ipywidget_slider(self, widget):
-        # setup an ipywidget slider with bidirectional callbacks to this LinearSelector
-        value = self.selection
-
-        if isinstance(widget, ipywidgets.IntSlider):
-            value = int(value)
-
-        widget.value = value
-
-        # user changes widget -> linear selection changes
-        widget.observe(self._ipywidget_callback, "value")
-
-        self._handled_widgets.append(widget)
-
-    def _update_ipywidgets(self, ev):
-        # update the ipywidget sliders when LinearSelector value changes
-        self._block_ipywidget_call = True  # prevent infinite recursion
-
-        value = ev.info["value"]
-        # update all the handled slider widgets
-        for widget in self._handled_widgets:
-            if isinstance(widget, ipywidgets.IntSlider):
-                widget.value = int(value)
-            else:
-                widget.value = value
-
-        self._block_ipywidget_call = False
-
-    def _ipywidget_callback(self, change):
-        # update the LinearSelector when the ipywidget value changes
-        if self._block_ipywidget_call or self._moving:
-            return
-
-        self.selection = change["new"]
-
-    def _fpl_add_plot_area_hook(self, plot_area):
-        super()._fpl_add_plot_area_hook(plot_area=plot_area)
-
-        # resize the slider widgets when the canvas is resized
-        self._plot_area.renderer.add_event_handler(self._set_slider_layout, "resize")
-
-    def _set_slider_layout(self, *args):
-        w, h = self._plot_area.renderer.logical_size
-
-        for widget in self._handled_widgets:
-            widget.layout = ipywidgets.Layout(width=f"{w}px")
-
-    def make_ipywidget_slider(self, kind: str = "IntSlider", **kwargs):
-        """
-        Makes and returns an ipywidget slider that is associated to this LinearSelector
-
-        Parameters
-        ----------
-        kind: str
-            "IntSlider", "FloatSlider" or "FloatLogSlider"
-
-        kwargs
-            passed to the ipywidget slider constructor
-
-        Returns
-        -------
-        ipywidgets.Intslider or ipywidgets.FloatSlider
-
-        """
-
-        if not IS_JUPYTER:
-            raise ImportError(
-                "Must installed `ipywidgets` to use `make_ipywidget_slider()`"
-            )
-
-        if kind not in ["IntSlider", "FloatSlider", "FloatLogSlider"]:
-            raise TypeError(
-                f"`kind` must be one of: 'IntSlider', 'FloatSlider' or 'FloatLogSlider'\n"
-                f"You have passed: '{kind}'"
-            )
-
-        cls = getattr(ipywidgets, kind)
-
-        value = self.selection
-        if "Int" in kind:
-            value = int(self.selection)
-
-        slider = cls(
-            min=self.limits[0],
-            max=self.limits[1],
-            value=value,
-            **kwargs,
-        )
-        self.add_ipywidget_handler(slider)
-
-        return slider
-
-    def add_ipywidget_handler(self, widget, step: Union[int, float] = None):
-        """
-        Bidirectionally connect events with a ipywidget slider
-
-        Parameters
-        ----------
-        widget: ipywidgets.IntSlider, ipywidgets.FloatSlider, or ipywidgets.FloatLogSlider
-            ipywidget slider to connect to
-
-        step: int or float, default ``None``
-            step size, if ``None`` 100 steps are created
-
-        """
-
-        if not isinstance(
-            widget,
-            (ipywidgets.IntSlider, ipywidgets.FloatSlider, ipywidgets.FloatLogSlider),
-        ):
-            raise TypeError(
-                f"`widget` must be one of: ipywidgets.IntSlider, ipywidgets.FloatSlider, or ipywidgets.FloatLogSlider\n"
-                f"You have passed a: <{type(widget)}"
-            )
-
-        if step is None:
-            step = (self.limits[1] - self.limits[0]) / 100
-
-        if isinstance(widget, ipywidgets.IntSlider):
-            step = int(step)
-
-        widget.step = step
-
-        self._setup_ipywidget_slider(widget)
-
     def get_selected_index(self, graphic: Graphic = None) -> Union[int, List[int]]:
         """
-        Data index the slider is currently at w.r.t. the Graphic data. With LineGraphic data, the geometry x or y
+        Data index the selector is currently at w.r.t. the Graphic data. With LineGraphic data, the geometry x or y
         position is not always the data position, for example if plotting data using np.linspace. Use this to get
-        the data index of the slider.
+        the data index of the selector.
 
         Parameters
         ----------
         graphic: Graphic, optional
-            Graphic to get the selected data index from. Default is the parent graphic associated to the slider.
+            Graphic to get the selected data index from. Default is the parent graphic associated to the selector.
 
         Returns
         -------
         int or List[int]
-            data index the slider is currently at, list of ``int`` if a Collection
+            data index the selector is currently at, list of ``int`` if a Collection
         """
 
         source = self._get_source(graphic)
@@ -354,10 +216,10 @@ class LinearSelector(BaseSelector):
             "Line" in graphic.__class__.__name__
             or "Scatter" in graphic.__class__.__name__
         ):
-            # we want to find the index of the data closest to the slider position
+            # we want to find the index of the data closest to the selector position
             find_value = self.selection
 
-            # get closest data index to the world space position of the slider
+            # get closest data index to the world space position of the selector
             idx = np.searchsorted(data, find_value, side="left")
 
             if idx > 0 and (
@@ -398,9 +260,3 @@ class LinearSelector(BaseSelector):
             self.selection = self.selection + delta[0]
         else:
             self.selection = self.selection + delta[1]
-
-    def _fpl_prepare_del(self):
-        for widget in self._handled_widgets:
-            widget.unobserve(self._ipywidget_callback, "value")
-
-        super()._fpl_prepare_del()


### PR DESCRIPTION
removes ipywidget code from selectors since we've now moved to imgui and shouldn't have any GUI-framework specific code in core fastplotlib

superseeds #631 since there was an issue with an lfs file