### PR TITLE
remove ipywidget code from selectors and cleanup docstrings

### DIFF
--- a/docs/source/api/selectors/LinearRegionSelector.rst
+++ b/docs/source/api/selectors/LinearRegionSelector.rst
@@ -43,12 +43,10 @@ Methods
 
     LinearRegionSelector.add_axes
     LinearRegionSelector.add_event_handler
-    LinearRegionSelector.add_ipywidget_handler
     LinearRegionSelector.clear_event_handlers
     LinearRegionSelector.get_selected_data
     LinearRegionSelector.get_selected_index
     LinearRegionSelector.get_selected_indices
-    LinearRegionSelector.make_ipywidget_slider
     LinearRegionSelector.remove_event_handler
     LinearRegionSelector.rotate
     LinearRegionSelector.share_property

--- a/docs/source/api/selectors/LinearSelector.rst
+++ b/docs/source/api/selectors/LinearSelector.rst
@@ -43,12 +43,10 @@ Methods
 
     LinearSelector.add_axes
     LinearSelector.add_event_handler
-    LinearSelector.add_ipywidget_handler
     LinearSelector.clear_event_handlers
     LinearSelector.get_selected_data
     LinearSelector.get_selected_index
     LinearSelector.get_selected_indices
-    LinearSelector.make_ipywidget_slider
     LinearSelector.remove_event_handler
     LinearSelector.rotate
     LinearSelector.share_property

--- a/fastplotlib/graphics/selectors/_linear.py
+++ b/fastplotlib/graphics/selectors/_linear.py
@@ -265,9 +265,3 @@ class LinearSelector(BaseSelector):
             self.selection = self.selection + delta[0]
         else:
             self.selection = self.selection + delta[1]
-
-    def _fpl_prepare_del(self):
-        for widget in self._handled_widgets:
-            widget.unobserve(self._ipywidget_callback, "value")
-
-        super()._fpl_prepare_del()


### PR DESCRIPTION
since we've not switched to imgui we shouldn't have any GUI specific code in the core library, this really cleans up the selectors :smile: 
