### PR TITLE
update github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,15 +33,15 @@ jobs:
     - name: Install git-lfs
       run: |
         sudo apt install --no-install-recommends -y  git-lfs
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.pyversion }}
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq
-        sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
+        sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip setuptools
@@ -63,7 +63,7 @@ jobs:
         WGPU_FORCE_OFFSCREEN=1 pytest -v tests/
         pytest -v examples
         FASTPLOTLIB_NB_TESTS=1 pytest --nbmake examples/notebooks/
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
         name: screenshot-diffs
@@ -90,15 +90,15 @@ jobs:
     - name: Install git-lfs
       run: |
         sudo apt install --no-install-recommends -y  git-lfs
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.pyversion }}
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq
-        sudo apt-get install --no-install-recommends -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
+        sudo apt-get install --no-install-recommends -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip setuptools
@@ -119,7 +119,7 @@ jobs:
       run: |
         WGPU_FORCE_OFFSCREEN=1 pytest -v tests/
         pytest -v examples
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
         name: screenshot-diffs

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install llvmpipe and lavapipe for offscreen canvas
         run: |
           sudo apt-get update -y -qq
-          sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
+          sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
       - name: Install dev dependencies
         run: |
           python -m pip install --upgrade pip setuptools

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -24,13 +24,13 @@ jobs:
     - name: Install git-lfs
       run: |
         sudo apt install --no-install-recommends -y  git-lfs
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: fetch git lfs files
       run: |
         git lfs fetch --all
         git lfs pull
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install dependencies

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -20,15 +20,15 @@ jobs:
       - name: Install git-lfs
         run: |
           sudo apt install --no-install-recommends -y  git-lfs
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install llvmpipe and lavapipe for offscreen canvas
         run: |
           sudo apt-get update -y -qq
-          sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+          sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
       - name: Install dev dependencies
         run: |
           python -m pip install --upgrade pip setuptools


### PR DESCRIPTION
- `libegl1-mesa` does not exist in Ubuntu 24.04 which is [now used by github actions servers](https://github.com/actions/runner-images/issues/10636), will see if `libegl1-mesa-dev` which does exist is a substitute. @almarklein also relevant for pygfx, wgpu . See https://github.com/fastplotlib/fastplotlib/actions/runs/11323476618/job/31486223347#step:5:12
- update all our actions verisons
