### PR TITLE
cleanup CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,12 @@ jobs:
             pyversion: '3.11'
           - name: Test py312
             pyversion: '3.12'
+          - name: Test py313
+            pyversion: '3.13'
     steps:
-    - name: Install git-lfs
-      run: |
-        sudo apt install --no-install-recommends -y  git-lfs
     - uses: actions/checkout@v4
+      with:
+        lfs: true
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -41,7 +42,7 @@ jobs:
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq
-        sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
+        sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip setuptools
@@ -71,7 +72,7 @@ jobs:
           examples/diffs
           examples/notebooks/diffs
 
-  test-build-desktop:
+  test-build-offscreen:
     name: Test Linux, only offscreen
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -86,11 +87,12 @@ jobs:
             pyversion: '3.11'
           - name: Test py312
             pyversion: '3.12'
+          - name: Test py313
+            pyversion: '3.13'
     steps:
-    - name: Install git-lfs
-      run: |
-        sudo apt install --no-install-recommends -y  git-lfs
     - uses: actions/checkout@v4
+      with:
+        lfs: true
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -98,7 +100,7 @@ jobs:
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq
-        sudo apt-get install --no-install-recommends -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
+        sudo apt-get install --no-install-recommends -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip setuptools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
             pyversion: '3.11'
           - name: Test py312
             pyversion: '3.12'
-          - name: Test py313
-            pyversion: '3.13'
     steps:
     - uses: actions/checkout@v4
       with:
@@ -87,8 +85,6 @@ jobs:
             pyversion: '3.11'
           - name: Test py312
             pyversion: '3.12'
-          - name: Test py313
-            pyversion: '3.13'
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install llvmpipe and lavapipe for offscreen canvas
         run: |
           sudo apt-get update -y -qq
-          sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers git-lfs
+          sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
       - name: Install dev dependencies
         run: |
           python -m pip install --upgrade pip setuptools

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -21,14 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install git-lfs
-      run: |
-        sudo apt install --no-install-recommends -y  git-lfs
     - uses: actions/checkout@v4
-    - name: fetch git lfs files
-      run: |
-        git lfs fetch --all
-        git lfs pull
+      with:
+        lfs: true
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -40,7 +35,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -17,10 +17,9 @@ jobs:
     timeout-minutes: 10
     if: ${{ !github.event.pull_request.draft }}
     steps:
-      - name: Install git-lfs
-        run: |
-          sudo apt install --no-install-recommends -y  git-lfs
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -39,10 +38,6 @@ jobs:
       - name: Show wgpu backend
         run:
           python -c "from examples.tests.testutils import wgpu_backend; print(wgpu_backend)"
-      - name: fetch git lfs files
-        run: |
-          git lfs fetch --all
-          git lfs pull
       - name: Test examples
         env:
           PYGFX_EXPECT_LAVAPIPE: true


### PR DESCRIPTION
- just use `with: lfs: true` with `actions/checkout`, remove explicit apt install of `git-lfs`
- use release version of pypi publish action
- ~add python3.13~ I think we need to wait for the next built wheels of `imgui-bundle` to release, I wonder if it's to do with `scikit_build_core` since that's what it uses? Anyways python 3.13 is brand new so we can wait a few months. 
