### PR TITLE
Delete apt.txt

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -1,3 +1,0 @@
-libvulkan1
-mesa-vulkan-drivers
-neofetch


### PR DESCRIPTION
I'm pretty sure this is there from when I was trying to see if fpl can work in binder. Anyways we have instruction on how to use fpl in cloud compute so this isn't necessary.
