### PR TITLE
update comments for image data shapes

### DIFF
--- a/fastplotlib/graphics/_features/_image.py
+++ b/fastplotlib/graphics/_features/_image.py
@@ -94,7 +94,7 @@ class TextureArray(GraphicFeature):
         if data.ndim not in (2, 3):
             raise ValueError(
                 "image data must be 2D with or without an RGB(A) dimension, i.e. "
-                "it must be of shape [x, y], [x, y, 3] or [x, y, 4]"
+                "it must be of shape [rows, cols], [rows, cols, 3] or [rows, cols, 4]"
             )
 
         # let's just cast to float32 always

--- a/fastplotlib/graphics/image.py
+++ b/fastplotlib/graphics/image.py
@@ -91,7 +91,7 @@ class ImageGraphic(Graphic):
         ----------
         data: array-like
             array-like, usually numpy.ndarray, must support ``memoryview()``
-            | shape must be ``[x_dim, y_dim]``
+            | shape must be ``[n_rows, n_cols]``, ``[n_rows, n_cols, 3]`` for RGB or ``[n_rows, n_cols, 4]`` for RGBA
 
         vmin: int, optional
             minimum value for color scaling, calculated from data if not provided

--- a/fastplotlib/widgets/image_widget/_widget.py
+++ b/fastplotlib/widgets/image_widget/_widget.py
@@ -12,8 +12,9 @@ from ...tools import HistogramLUTTool
 from ._sliders import ImageWidgetSliders
 
 
-# Number of dimensions that represent one image/one frame. For grayscale shape will be [x, y], i.e. 2 dims, for RGB(A)
-# shape will be [x, y, c] where c is of size 3 (RGB) or 4 (RGBA)
+# Number of dimensions that represent one image/one frame
+# For grayscale shape will be [n_rows, n_cols], i.e. 2 dims
+# For RGB(A) shape will be [n_rows, n_cols, c] where c is of size 3 (RGB) or 4 (RGBA)
 IMAGE_DIM_COUNTS = {"gray": 2, "rgb": 3}
 
 # Map boolean (indicating whether we use RGB or grayscale) to the string. Used to index RGB_DIM_MAP
@@ -162,7 +163,7 @@ class ImageWidget:
     def n_scrollable_dims(self) -> list[int]:
         """
         list indicating the number of dimenensions that are scrollable for each data array
-        All other dimensions are frame/image data, i.e. [x, y] or [x, y, c]
+        All other dimensions are frame/image data, i.e. [rows, cols] or [rows, cols, rgb(a)]
         """
         return self._n_scrollable_dims
 


### PR DESCRIPTION
changes all the incorrect `[x, y]` shape comments to `[rows, cols]`
