### PR TITLE
fix typo in the requested limit name of the wgpu device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq
-        sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+        sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers xorg-dev
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip setuptools
@@ -96,7 +96,7 @@ jobs:
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq
-        sudo apt-get install --no-install-recommends -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+        sudo apt-get install --no-install-recommends -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers xorg-dev
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip setuptools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
   test-build-offscreen:
     name: Test Linux, only offscreen
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   test-build-full:
     name: Test Linux, notebook + offscreen
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@ from sphinx_gallery.sorting import ExplicitOrder
 import imageio.v3 as iio
 
 MAX_TEXTURE_SIZE = 2048
-pygfx.renderers.wgpu.set_wgpu_limits(**{"max-texture-dimension2d": MAX_TEXTURE_SIZE})
+pygfx.renderers.wgpu.set_wgpu_limits(**{"max-texture-dimension-2d": MAX_TEXTURE_SIZE})
 
 ROOT_DIR = Path(__file__).parents[1].parents[0]  # repo root
 EXAMPLES_DIR = Path.joinpath(ROOT_DIR, "examples")

--- a/docs/source/user_guide/gpu.rst
+++ b/docs/source/user_guide/gpu.rst
@@ -235,38 +235,38 @@ Example output::
 
                                                       adapter  device
 
-                                    max_bind_groups:        8       8
-                max_bind_groups_plus_vertex_buffers:        0       0
-                        max_bindings_per_bind_group:    1.00K   1.00K
-                                    max_buffer_size:    2.14G   2.14G
-              max_color_attachment_bytes_per_sample:        0       0
-                              max_color_attachments:        0       0
-              max_compute_invocations_per_workgroup:    1.02K   1.02K
-                       max_compute_workgroup_size_x:    1.02K   1.02K
-                       max_compute_workgroup_size_y:    1.02K   1.02K
-                       max_compute_workgroup_size_z:    1.02K   1.02K
-                 max_compute_workgroup_storage_size:    32.7K   32.7K
-               max_compute_workgroups_per_dimension:    65.5K   65.5K
-    max_dynamic_storage_buffers_per_pipeline_layout:        8       8
-    max_dynamic_uniform_buffers_per_pipeline_layout:       16      16
-                  max_inter_stage_shader_components:      128     128
-                   max_inter_stage_shader_variables:        0       0
-              max_sampled_textures_per_shader_stage:    8.38M   8.38M
-                      max_samplers_per_shader_stage:    8.38M   8.38M
-                    max_storage_buffer_binding_size:    2.14G   2.14G
-               max_storage_buffers_per_shader_stage:    8.38M   8.38M
-              max_storage_textures_per_shader_stage:    8.38M   8.38M
-                           max_texture_array_layers:    2.04K   2.04K
-                            max_texture_dimension1d:    16.3K   16.3K
-                            max_texture_dimension2d:    16.3K   16.3K
-                            max_texture_dimension3d:    2.04K   2.04K
-                    max_uniform_buffer_binding_size:    2.14G   2.14G
-               max_uniform_buffers_per_shader_stage:    8.38M   8.38M
-                              max_vertex_attributes:       32      32
-                     max_vertex_buffer_array_stride:    2.04K   2.04K
-                                 max_vertex_buffers:       16      16
-                min_storage_buffer_offset_alignment:       32      32
-                min_uniform_buffer_offset_alignment:       32      32
+                                    max-bind-groups:        8       8
+                max-bind-groups-plus-vertex-buffers:        0       0
+                        max-bindings-per-bind-group:    1.00K   1.00K
+                                    max-buffer-size:    2.14G   2.14G
+              max-color-attachment-bytes-per-sample:        0       0
+                              max-color-attachments:        0       0
+              max-compute-invocations-per-workgroup:    1.02K   1.02K
+                       max-compute-workgroup-size-x:    1.02K   1.02K
+                       max-compute-workgroup-size-y:    1.02K   1.02K
+                       max-compute-workgroup-size-z:    1.02K   1.02K
+                 max-compute-workgroup-storage-size:    32.7K   32.7K
+               max-compute-workgroups-per-dimension:    65.5K   65.5K
+    max-dynamic-storage-buffers-per-pipeline-layout:        8       8
+    max-dynamic-uniform-buffers-per-pipeline-layout:       16      16
+                  max-inter-stage-shader-components:      128     128
+                   max-inter-stage-shader-variables:        0       0
+              max-sampled-textures-per-shader-stage:    8.38M   8.38M
+                      max-samplers-per-shader-stage:    8.38M   8.38M
+                    max-storage-buffer-binding-size:    2.14G   2.14G
+               max-storage-buffers-per-shader-stage:    8.38M   8.38M
+              max-storage-textures-per-shader-stage:    8.38M   8.38M
+                           max-texture-array-layers:    2.04K   2.04K
+                           max-texture-dimension-1d:    16.3K   16.3K
+                           max-texture-dimension-2d:    16.3K   16.3K
+                           max-texture-dimension-3d:    2.04K   2.04K
+                    max-uniform-buffer-binding-size:    2.14G   2.14G
+               max-uniform-buffers-per-shader-stage:    8.38M   8.38M
+                              max-vertex-attributes:       32      32
+                     max-vertex-buffer-array-stride:    2.04K   2.04K
+                                 max-vertex-buffers:       16      16
+                min-storage-buffer-offset-alignment:       32      32
+                min-uniform-buffer-offset-alignment:       32      32
 
     ██ pygfx_caches:
 

--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -12,7 +12,7 @@ import imageio.v3 as iio
 import pygfx
 
 MAX_TEXTURE_SIZE = 2048
-pygfx.renderers.wgpu.set_wgpu_limits(**{"max-texture-dimension2d": MAX_TEXTURE_SIZE})
+pygfx.renderers.wgpu.set_wgpu_limits(**{"max-texture-dimension-2d": MAX_TEXTURE_SIZE})
 
 from .testutils import (
     ROOT,

--- a/fastplotlib/graphics/_features/_image.py
+++ b/fastplotlib/graphics/_features/_image.py
@@ -21,7 +21,7 @@ class TextureArray(GraphicFeature):
         data = self._fix_data(data)
 
         shared = pygfx.renderers.wgpu.get_shared()
-        self._texture_limit_2d = shared.device.limits["max-texture-dimension2d"]
+        self._texture_limit_2d = shared.device.limits["max-texture-dimension-2d"]
 
         if isolated_buffer:
             # useful if data is read-only, example: memmaps

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,4 +5,4 @@ MAX_TEXTURE_SIZE = 1024
 
 
 def pytest_sessionstart(session):
-    pygfx.renderers.wgpu.set_wgpu_limits(**{"max-texture-dimension2d": MAX_TEXTURE_SIZE})
+    pygfx.renderers.wgpu.set_wgpu_limits(**{"max-texture-dimension-2d": MAX_TEXTURE_SIZE})


### PR DESCRIPTION
Hi,

when running different examples involving images, the following exception is raised:

```python
Traceback (most recent call last):
  File "***\fastplotlib\examples\gridplot\gridplot_non_square.py", line 20, in <module>
    figure[0, 0].add_image(data=im)
  File "***\fastplotlib\fastplotlib\layouts\_graphic_methods_mixin.py", line 75, in add_image
    return self._create_graphic(
           ^^^^^^^^^^^^^^^^^^^^^
  File "***\fastplotlib\fastplotlib\layouts\_graphic_methods_mixin.py", line 24, in _create_graphic
    graphic = graphic_class(*args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\fastplotlib\fastplotlib\graphics\image.py", line 126, in __init__
    self._data = TextureArray(data, isolated_buffer=isolated_buffer)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\fastplotlib\fastplotlib\graphics\_features\_image.py", line 24, in __init__
    self._texture_limit_2d = shared.device.limits["max-texture-dimension2d"]
                             ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'max-texture-dimension2d'
```

It fails for the following examples (non-exhaustive list), on windows10, python 3.12.6, pygfx 0.6.0, wgpu 0.19.1 (can't test right now on linux because of an error related to imgui):
- example/gridplot/*
- heatmap/heatmap.py
- image/*

I believe there's a typo in the string passed to the `limits` property of the `wgpu.Device` object. From the wgpu documentation (Rust), the constant is named 'max_texture_dimension_2d', at least since wgpu-0.10.1:
https://docs.rs/wgpu/latest/wgpu/struct.Limits.html#structfield.max_texture_dimension_2d

By appling the lower-case style, the examples now work by adding an hyphen before "2d". I don't know if it is specific to my setup, but this fix seems to be aligned with the wgpu API.