### PR TITLE
use imageio[ffmpeg] instead of pyav

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras_require = {
     "tests-desktop": [
         "pytest<8.0.0",
         "scipy",
-        "imageio[pyav]",
+        "imageio[ffmpeg]",
         "scikit-learn",
         "tqdm",
         "imgui-bundle",


### PR DESCRIPTION
Changes in the latest pyav have been blocking things: https://github.com/imageio/imageio/issues/1111

Let's switch to using ffmpeg instead, it's sufficient for our use case which is examples and docs. `imageio-ffmpeg` ships the binaries with the wheels for all OSses: https://github.com/imageio/imageio-ffmpeg?tab=readme-ov-file#installation
