### PR TITLE
small wgpu changes

### DIFF
--- a/fastplotlib/__init__.py
+++ b/fastplotlib/__init__.py
@@ -24,7 +24,8 @@ with open(Path(__file__).parent.joinpath("VERSION"), "r") as f:
     __version__ = f.read().split("\n")[0]
 
 if len(enumerate_adapters()) < 1:
-    raise IndexError(
+    from warnings import warn
+    warn(
         f"WGPU could not enumerate any adapters, fastplotlib will not work.\n"
         f"This is caused by one of the following:\n"
         f"1. You do not have a hardware GPU installed and you do not have "
@@ -35,5 +36,6 @@ if len(enumerate_adapters()) < 1:
         f"common in cloud computing environments.\n"
         f"These two links can help you troubleshoot:\n"
         f"https://wgpu-py.readthedocs.io/en/stable/start.html#platform-requirements\n"
-        f"https://fastplotlib.readthedocs.io/en/latest/user_guide/gpu.html\n"
+        f"https://fastplotlib.readthedocs.io/en/latest/user_guide/gpu.html\n",
+        RuntimeWarning,
     )

--- a/fastplotlib/__init__.py
+++ b/fastplotlib/__init__.py
@@ -25,6 +25,7 @@ with open(Path(__file__).parent.joinpath("VERSION"), "r") as f:
 
 if len(enumerate_adapters()) < 1:
     from warnings import warn
+
     warn(
         f"WGPU could not enumerate any adapters, fastplotlib will not work.\n"
         f"This is caused by one of the following:\n"

--- a/fastplotlib/utils/gui.py
+++ b/fastplotlib/utils/gui.py
@@ -59,10 +59,10 @@ def _notebook_print_banner():
     image = Image(value=logo_data, format="png", width=300, height=55)
 
     # get adapters and info
-    adapters = [a for a in wgpu.gpu.enumerate_adapters()]
+    adapters = [a for a in wgpu.gpu.enumerate_adapters_sync()]
     adapters_info = [a.info for a in adapters]
 
-    default_adapter_info = wgpu.gpu.request_adapter().info
+    default_adapter_info = wgpu.gpu.request_adapter_sync().info
     default_ix = adapters_info.index(default_adapter_info)
 
     if len(adapters) < 1:


### PR DESCRIPTION
- fix deprecated wgpu calls
- show a warning instead of raising an exception upon import if no wgpu adapters are found. I think it's probably not the best behavior to raise exception on import for something like this, a warning is more appropriate
