### PR TITLE
update python versions for CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Test py310
-            pyversion: '3.10'
           - name: Test py311
             pyversion: '3.11'
           - name: Test py312
             pyversion: '3.12'
+          - name: Test py313
+            pyversion: '3.13'
     steps:
     - uses: actions/checkout@v4
       with:
@@ -79,12 +79,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Test py310
-            pyversion: '3.10'
           - name: Test py311
             pyversion: '3.11'
           - name: Test py312
             pyversion: '3.12'
+          - name: Test py313
+            pyversion: '3.13'
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -20,10 +20,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install llvmpipe and lavapipe for offscreen canvas
         run: |
           sudo apt-get update -y -qq


### PR DESCRIPTION
drop python3.10 from CI and add python3.13, mainly since [imgui-bundle now only provides wheels for python3.11-3.13](https://pypi.org/project/imgui-bundle/1.6.2/#files) in the latest release. It has to build imgui from source on python3.10 which slows down that github action job. Python 3.10 will be dropped from NEP29 in a few months anyways, we can continue unofficially supporting 3.10 meanwhile. 

also updates python versions for publish and deploy docs actions
