### PR TITLE
Fix imgui popup menus

### DIFF
--- a/fastplotlib/ui/_base.py
+++ b/fastplotlib/ui/_base.py
@@ -248,8 +248,6 @@ class Popup(BaseGUI):
         self._figure = figure
         self._fa_icons = self._figure._fa_icons
 
-        self._event_filter_names = set()
-
         self.is_open = False
 
     def open(self, pos: tuple[int, int], *args, **kwargs):

--- a/fastplotlib/ui/right_click_menus/_colormap_picker.py
+++ b/fastplotlib/ui/right_click_menus/_colormap_picker.py
@@ -153,7 +153,7 @@ class ColormapPicker(Popup):
                 * imgui.get_font().font_size
             ) - 2
 
-            if imgui.menu_item("Reset vmin-vmax", None, False)[0]:
+            if imgui.menu_item("Reset vmin-vmax", "", False)[0]:
                 self._lut_tool.image_graphic.reset_vmin_vmax()
 
             # add all the cmap options

--- a/fastplotlib/ui/right_click_menus/_standard_menu.py
+++ b/fastplotlib/ui/right_click_menus/_standard_menu.py
@@ -82,14 +82,14 @@ class StandardRightClickMenu(Popup):
             imgui.separator()
 
             # autoscale, center, maintain aspect
-            if imgui.menu_item(f"Autoscale", None, False)[0]:
+            if imgui.menu_item(f"Autoscale", "", False)[0]:
                 self.get_subplot().auto_scale()
 
-            if imgui.menu_item(f"Center", None, False)[0]:
+            if imgui.menu_item(f"Center", "", False)[0]:
                 self.get_subplot().center_scene()
 
             _, maintain_aspect = imgui.menu_item(
-                "Maintain Aspect", None, self.get_subplot().camera.maintain_aspect
+                "Maintain Aspect", "", self.get_subplot().camera.maintain_aspect
             )
             self.get_subplot().camera.maintain_aspect = maintain_aspect
 
@@ -98,7 +98,7 @@ class StandardRightClickMenu(Popup):
             # toggles to flip axes cameras
             for axis in ["x", "y", "z"]:
                 scale = getattr(self.get_subplot().camera.local, f"scale_{axis}")
-                changed, flip = imgui.menu_item(f"Flip {axis} axis", None, scale < 0)
+                changed, flip = imgui.menu_item(f"Flip {axis} axis", "", bool(scale < 0))
 
                 if changed:
                     flip_axis(self.get_subplot(), axis, flip)
@@ -109,7 +109,7 @@ class StandardRightClickMenu(Popup):
             for plane in ["xy", "xz", "yz"]:
                 grid = getattr(self.get_subplot().axes.grids, plane)
                 visible = grid.visible
-                changed, new_visible = imgui.menu_item(f"Grid {plane}", None, visible)
+                changed, new_visible = imgui.menu_item(f"Grid {plane}", "", visible)
 
                 if changed:
                     grid.visible = new_visible
@@ -140,7 +140,7 @@ class StandardRightClickMenu(Popup):
             # controller options
             if imgui.begin_menu("Controller"):
                 _, enabled = imgui.menu_item(
-                    "Enabled", None, self.get_subplot().controller.enabled
+                    "Enabled", "", self.get_subplot().controller.enabled
                 )
 
                 self.get_subplot().controller.enabled = enabled
@@ -163,7 +163,7 @@ class StandardRightClickMenu(Popup):
 
                     clicked, _ = imgui.menu_item(
                         label=name,
-                        shortcut=None,
+                        shortcut="",
                         p_selected=current_type is controller_type_iter,
                     )
 

--- a/fastplotlib/ui/right_click_menus/_standard_menu.py
+++ b/fastplotlib/ui/right_click_menus/_standard_menu.py
@@ -98,7 +98,9 @@ class StandardRightClickMenu(Popup):
             # toggles to flip axes cameras
             for axis in ["x", "y", "z"]:
                 scale = getattr(self.get_subplot().camera.local, f"scale_{axis}")
-                changed, flip = imgui.menu_item(f"Flip {axis} axis", "", bool(scale < 0))
+                changed, flip = imgui.menu_item(
+                    f"Flip {axis} axis", "", bool(scale < 0)
+                )
 
                 if changed:
                     flip_axis(self.get_subplot(), axis, flip)


### PR DESCRIPTION
fixes #694 

The kwargs for the imgui popup menu for right clicks got more strict in the v1.6.0 release. Was annoying to troubleshoot since I was first getting errors stating that the previous imgui frame had not been ended and to call `imgui.end_frame()`. So then I added an extra `imgui.end_frame()` within the right click menu and it produced the actual error which was that imgui wasn't happy with the types of the kwargs :man_shrugging: 

So before we had things like this for example:

```python
imgui.menu_item("item name", None, val > 0)

# signature
menu_item(str, str, bool)
```
args are: (item name, keyboard shortcut, selected)

So before it worked if we gave `None` for the second arg which is keyboard shortcut, now it has to explicitly be `""`. And it's not taking expressions that results in a `bool` for whatever reason anymore.

So in summary the above needs to become the following for imgui v1.6.0 to be happy:

```python
menu_item("item name", "", bool(val > 0))
```
