### PR TITLE
remove glfw import that leaked in

### DIFF
--- a/examples/image_widget/image_widget.py
+++ b/examples/image_widget/image_widget.py
@@ -10,7 +10,7 @@ colorbar to pick colormaps.
 
 # test_example = true
 # sphinx_gallery_pygfx_docs = 'screenshot'
-import glfw
+
 import fastplotlib as fpl
 import imageio.v3 as iio  # not a fastplotlib dependency, only used for examples
 


### PR DESCRIPTION
IDK where this leaked in from

I was getting wayland errors so I was wondering why wayland doesn't like image widgets specifically and then I realized the glfw import :laughing: 
