### PR TITLE
add job that uses release version of pygfx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,70 @@ jobs:
           examples/diffs
           examples/notebooks/diffs
 
+jobs:
+  test-using-pygfx-release:
+    name: Test Linux pygfx release
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    if: ${{ !github.event.pull_request.draft }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.11", "3.12", "3.13"]
+        imgui_dep: ["imgui", ""]
+        notebook_dep: ["notebook", ""]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        lfs: true
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install llvmpipe and lavapipe for offscreen canvas
+      run: |
+        sudo apt-get update -y -qq
+        sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers xorg-dev
+    - name: Install fastplotlib
+      run: |
+        # create string with one of: tests,imgui,notebook; test,imgui; test,notebook ; tests
+        # sed removes trailing comma
+        # install fastplotlib with given extras options from above
+        pip install -e ".[$(echo "tests,${{ matrix.imgui_dep }},${{ matrix.notebook_dep }}" | sed -e "s/,\+/,/g" -e "s/,$//")]"
+    - name: Show wgpu backend
+      run:
+        python -c "from examples.tests.testutils import wgpu_backend; print(wgpu_backend)"
+    - name: Test components
+      env:
+        PYGFX_EXPECT_LAVAPIPE: true
+      run: |
+        WGPU_FORCE_OFFSCREEN=1 pytest -v tests/
+    - name: Test examples
+      env:
+        PYGFX_EXPECT_LAVAPIPE: true
+      run: |
+        WGPU_FORCE_OFFSCREEN=1 pytest -v examples/
+    - name: Test examples notebooks, exclude ImageWidget notebook
+      if: ${{ matrix.notebook_dep == 'notebook' }}
+      env:
+        PYGFX_EXPECT_LAVAPIPE: true
+      # test notebooks, exclude ImageWidget notebooks
+      run: FASTPLOTLIB_NB_TESTS=1 pytest --nbmake $(find ./examples/notebooks/ -maxdepth 1 -type f -name "*.ipynb" ! -name "image_widget*.ipynb" -print | xargs)
+    - name: Test ImageWidget notebooks
+      # test image widget notebooks only if imgui is installed
+      if: ${{ matrix.notebook_dep == 'notebook' && matrix.imgui_dep == 'imgui' }}
+      env:
+        PYGFX_EXPECT_LAVAPIPE: true
+      run: FASTPLOTLIB_NB_TESTS=1 pytest --nbmake $(find ./examples/notebooks/ -maxdepth 1 -type f -name "image_widget*.ipynb" -print | xargs)
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: screenshot-diffs-${{ matrix.pyversion }}-${{ matrix.imgui_dep }}-${{ matrix.notebook_dep }}
+        path: |
+          examples/diffs
+          examples/notebooks/diffs
 
+          
 #  test-build-full-mac:
 #    name: Test Mac, notebook + glfw
 #    runs-on: macos-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,7 @@ jobs:
         path: |
           examples/diffs
           examples/notebooks/diffs
-
-jobs:
+          
   test-using-pygfx-release:
     name: Test Linux pygfx release
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         sudo apt-get update -y -qq
         sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers xorg-dev
     - name: Install pygx from main
-      if: ${{ matrix.pygfx_version == 'pygfx-release' }}
+      if: ${{ matrix.pygfx_version == 'pygfx-main' }}
       run: |
         python -m pip install --upgrade pip setuptools
         # remove pygfx from install_requires, we install using pygfx@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         python: ["3.11", "3.12", "3.13"]
         imgui_dep: ["imgui", ""]
         notebook_dep: ["notebook", ""]
+        pygfx_version: ["pygfx-release", "pygfx-main"]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -38,6 +39,7 @@ jobs:
         sudo apt-get update -y -qq
         sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers xorg-dev
     - name: Install pygx from main
+      if: ${{ matrix.pygfx_version == 'pygfx-release' }}
       run: |
         python -m pip install --upgrade pip setuptools
         # remove pygfx from install_requires, we install using pygfx@main
@@ -81,70 +83,8 @@ jobs:
         path: |
           examples/diffs
           examples/notebooks/diffs
-          
-  test-using-pygfx-release:
-    name: Test Linux pygfx release
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    if: ${{ !github.event.pull_request.draft }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ["3.11", "3.12", "3.13"]
-        imgui_dep: ["imgui", ""]
-        notebook_dep: ["notebook", ""]
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        lfs: true
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install llvmpipe and lavapipe for offscreen canvas
-      run: |
-        sudo apt-get update -y -qq
-        sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers xorg-dev
-    - name: Install fastplotlib
-      run: |
-        # create string with one of: tests,imgui,notebook; test,imgui; test,notebook ; tests
-        # sed removes trailing comma
-        # install fastplotlib with given extras options from above
-        pip install -e ".[$(echo "tests,${{ matrix.imgui_dep }},${{ matrix.notebook_dep }}" | sed -e "s/,\+/,/g" -e "s/,$//")]"
-    - name: Show wgpu backend
-      run:
-        python -c "from examples.tests.testutils import wgpu_backend; print(wgpu_backend)"
-    - name: Test components
-      env:
-        PYGFX_EXPECT_LAVAPIPE: true
-      run: |
-        WGPU_FORCE_OFFSCREEN=1 pytest -v tests/
-    - name: Test examples
-      env:
-        PYGFX_EXPECT_LAVAPIPE: true
-      run: |
-        WGPU_FORCE_OFFSCREEN=1 pytest -v examples/
-    - name: Test examples notebooks, exclude ImageWidget notebook
-      if: ${{ matrix.notebook_dep == 'notebook' }}
-      env:
-        PYGFX_EXPECT_LAVAPIPE: true
-      # test notebooks, exclude ImageWidget notebooks
-      run: FASTPLOTLIB_NB_TESTS=1 pytest --nbmake $(find ./examples/notebooks/ -maxdepth 1 -type f -name "*.ipynb" ! -name "image_widget*.ipynb" -print | xargs)
-    - name: Test ImageWidget notebooks
-      # test image widget notebooks only if imgui is installed
-      if: ${{ matrix.notebook_dep == 'notebook' && matrix.imgui_dep == 'imgui' }}
-      env:
-        PYGFX_EXPECT_LAVAPIPE: true
-      run: FASTPLOTLIB_NB_TESTS=1 pytest --nbmake $(find ./examples/notebooks/ -maxdepth 1 -type f -name "image_widget*.ipynb" -print | xargs)
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: screenshot-diffs-${{ matrix.pyversion }}-${{ matrix.imgui_dep }}-${{ matrix.notebook_dep }}
-        path: |
-          examples/diffs
-          examples/notebooks/diffs
 
-          
+
 #  test-build-full-mac:
 #    name: Test Mac, notebook + glfw
 #    runs-on: macos-14


### PR DESCRIPTION
closes #702 

see this comment https://github.com/fastplotlib/fastplotlib/pull/706#issuecomment-2613724223

~Instead of adding it to the matrix I just made a new identical job so we can use the branch protection rules instead of the more complicated check and message system linked in that issue~

~Will see if this works, I've set "Test Linux" (which uses `pygfx@main`) as a required status check that must pass for a PR to be merged and I wonder if that will cover the entire matrix for that job. "Test Linux pygfx release" is however not required to pass.~
