### PR TITLE
separate CI workflow that uses release version of pygfx

### DIFF
--- a/.github/workflows/ci-pygfx-release.yml
+++ b/.github/workflows/ci-pygfx-release.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   test-build-full:
-    name: Tests
+    name: Tests - pygfx release
     timeout-minutes: 25
     if: ${{ !github.event.pull_request.draft }}
     strategy:

--- a/.github/workflows/ci-pygfx-release.yml
+++ b/.github/workflows/ci-pygfx-release.yml
@@ -1,0 +1,88 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  test-build-full:
+    name: Tests
+    timeout-minutes: 25
+    if: ${{ !github.event.pull_request.draft }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.11", "3.12", "3.13"]
+        imgui_dep: ["imgui", ""]
+        notebook_dep: ["notebook", ""]
+        os: ["ubuntu-latest", "macos-latest"]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        lfs: true
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install llvmpipe and lavapipe for offscreen canvas
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        sudo apt-get update -y -qq
+        sudo apt-get install --no-install-recommends -y ffmpeg libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers xorg-dev
+    - name: Set up Homebrew
+      if: ${{ matrix.os == 'macos-latest' }}
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+    - name: Install gsed
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        brew install gnu-sed
+        echo "/opt/homebrew/opt/gnu-sed/libexec/gnubin" >> "$GITHUB_PATH"
+    - name: Install fastplotlib
+      run: |
+        # create string with one of: tests,imgui,notebook; test,imgui; test,notebook ; tests
+        # sed removes trailing comma
+        # install fastplotlib with given extras options from above
+        pip install -e ".[$(echo "tests,${{ matrix.imgui_dep }},${{ matrix.notebook_dep }}" | sed -e "s/,\+/,/g" -e "s/,$//")]"
+    - name: Show wgpu backend
+      run:
+        python -c "from examples.tests.testutils import wgpu_backend; print(wgpu_backend)"
+    - name: Test components
+      env:
+        WGPU_FORCE_OFFSCREEN: 1
+      run: |
+        pytest -v tests/
+    - name: Test examples
+      env:
+        WGPU_FORCE_OFFSCREEN: 1
+      run: |
+        pytest -v examples/
+    - name: Test examples notebooks, exclude ImageWidget notebook
+      if: ${{ matrix.notebook_dep == 'notebook' }}
+      env:
+        FASTPLOTLIB_NB_TESTS: 1
+      # test notebooks, exclude ImageWidget notebooks
+      run: pytest --nbmake $(find ./examples/notebooks/ -maxdepth 1 -type f -name "*.ipynb" ! -name "image_widget*.ipynb" -print | xargs)
+    - name: Test ImageWidget notebooks
+      # test image widget notebooks only if imgui is installed
+      if: ${{ matrix.notebook_dep == 'notebook' && matrix.imgui_dep == 'imgui' }}
+      env:
+        FASTPLOTLIB_NB_TESTS: 1
+      run: pytest --nbmake $(find ./examples/notebooks/ -maxdepth 1 -type f -name "image_widget*.ipynb" -print | xargs)
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: screenshot-diffs-${{ matrix.pyversion }}-${{ matrix.imgui_dep }}-${{ matrix.notebook_dep }}
+        path: |
+          examples/diffs
+          examples/notebooks/diffs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
         python: ["3.11", "3.12", "3.13"]
         imgui_dep: ["imgui", ""]
         notebook_dep: ["notebook", ""]
-        pygfx_version: ["pygfx-release", "pygfx-main"]
         os: ["ubuntu-latest", "macos-latest"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -50,7 +49,6 @@ jobs:
         brew install gnu-sed
         echo "/opt/homebrew/opt/gnu-sed/libexec/gnubin" >> "$GITHUB_PATH"
     - name: Install pygx from main
-      if: ${{ matrix.pygfx_version == 'pygfx-main' }}
       run: |
         python -m pip install --upgrade pip setuptools
         # remove pygfx from install_requires, we install using pygfx@main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,5 +307,5 @@ FASTPLOTLIB_NB_TESTS=1 pytest --nbmake examples/notebooks/
 6) Push and open a PR (pull request) against the `main` branch
 
 > **Note:**
-> The tests labelled "CI / Tests" must pass, but the tests labelled "CI / Tests - pygfx release" do not necessarily need to pass. The difference between these two workflows is "CI / Tests" uses the `main` branch of [`pygfx`](https://github.com/pygfx/pygfx) whereas "CI / Tests - pygfx release" uses the latest release of `pygfx`.
+> The tests labeled "CI / Tests" must pass, but the tests labeled "CI / Tests - pygfx release" do not necessarily need to pass. The difference between these two workflows is "CI / Tests" uses the `main` branch of [`pygfx`](https://github.com/pygfx/pygfx) whereas "CI / Tests - pygfx release" uses the latest release of `pygfx`.
 > Since `fastplotlib`, `pygfx`, and `wgpu` are all under rapid development we aim to keep `fastplotlib` up to date with `pygfx@main` until `pygfx` stabilizes. The workflow "CI / Tests - pygfx release" is to inform us if any test failures using the release version of `pygfx` are a significant release blocker for `fastplotlib`. Once you make a PR we will help guide you through any failures with "CI / Tests - pygfx release"!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,5 +304,8 @@ FASTPLOTLIB_NB_TESTS=1 pytest --nbmake examples/notebooks/
 
 5) Update screenshots if necessary ([see testing](#testing-details))
 
-6) Push and open a draft PR against `main`
+6) Push and open a PR (pull request) against the `main` branch
 
+> **Note:**
+> The tests labelled "CI / Tests" must pass, but the tests labelled "CI / Tests - pygfx release" do not necessarily need to pass. The difference between these two workflows is "CI / Tests" uses the `main` branch of [`pygfx`](https://github.com/pygfx/pygfx) whereas "CI / Tests - pygfx release" uses the latest release of `pygfx`.
+> Since `fastplotlib`, `pygfx`, and `wgpu` are all under rapid development we aim to keep `fastplotlib` up to date with `pygfx@main` until `pygfx` stabilizes. The workflow "CI / Tests - pygfx release" is to inform us if any test failures using the release version of `pygfx` are a significant release blocker for `fastplotlib`. Once you make a PR we will help guide you through any failures with "CI / Tests - pygfx release"!


### PR DESCRIPTION
Until pygfx becomes more stable we will have 2 workflows. One that uses `pygfx@main` another that uses the latest pygfx from pypi. Slight maintenance burden but temporary.
