### PR TITLE
removes size attribute use for histogram component of imagewidget

### DIFF
--- a/fastplotlib/utils/functions.py
+++ b/fastplotlib/utils/functions.py
@@ -289,7 +289,7 @@ def quick_min_max(data: np.ndarray) -> tuple[float, float]:
         ):
             return data.min, data.max
 
-    while data.size > 1e6:
+    while np.prod(data.shape) > 1e6:
         ax = np.argmax(data.shape)
         sl = [slice(None)] * data.ndim
         sl[ax] = slice(None, None, 2)


### PR DESCRIPTION
Addresses issue #711, verified that .size is no longer a "required" property for lazy arrays used in ImageWidget. 