### PR TITLE
Update `WGPU_FORCE_OFFSCREEN` to `RENDERCANVAS_FORCE_OFFSCREEN`

### DIFF
--- a/.github/workflows/ci-pygfx-release.yml
+++ b/.github/workflows/ci-pygfx-release.yml
@@ -59,12 +59,12 @@ jobs:
         python -c "from examples.tests.testutils import wgpu_backend; print(wgpu_backend)"
     - name: Test components
       env:
-        WGPU_FORCE_OFFSCREEN: 1
+        RENDERCANVAS_FORCE_OFFSCREEN: 1
       run: |
         pytest -v tests/
     - name: Test examples
       env:
-        WGPU_FORCE_OFFSCREEN: 1
+        RENDERCANVAS_FORCE_OFFSCREEN: 1
       run: |
         pytest -v examples/
     - name: Test examples notebooks, exclude ImageWidget notebook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,12 @@ jobs:
         python -c "from examples.tests.testutils import wgpu_backend; print(wgpu_backend)"
     - name: Test components
       env:
-        WGPU_FORCE_OFFSCREEN: 1
+        RENDERCANVAS_FORCE_OFFSCREEN: 1
       run: |
         pytest -v tests/
     - name: Test examples
       env:
-        WGPU_FORCE_OFFSCREEN: 1
+        RENDERCANVAS_FORCE_OFFSCREEN: 1
       run: |
         pytest -v examples/
     - name: Test examples notebooks, exclude ImageWidget notebook

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -52,7 +52,7 @@ jobs:
           PYGFX_EXPECT_LAVAPIPE: true
         run: |
           # regenerate screenshots
-          WGPU_FORCE_OFFSCREEN=1 REGENERATE_SCREENSHOTS=1 pytest -v examples
+          RENDERCANVAS_FORCE_OFFSCREEN=1 REGENERATE_SCREENSHOTS=1 pytest -v examples
       - name: Generate screenshots notebook, exclude image widget
         env:
           PYGFX_EXPECT_LAVAPIPE: true


### PR DESCRIPTION
this changed when `wgpu-py` moved the gui stuff to `rendercanvas`, the old env var was there for backwards compatibility

@clewis7 gtg
