### PR TITLE
add `ImageVolumeGraphic`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,6 +56,7 @@ sphinx_gallery_conf = {
     "subsection_order": ExplicitOrder(
         [
             "../../examples/image",
+            "../../examples/image_volume",
             "../../examples/heatmap",
             "../../examples/image_widget",
             "../../examples/gridplot",

--- a/examples/image_volume/README.rst
+++ b/examples/image_volume/README.rst
@@ -1,0 +1,2 @@
+Image Volume Examples
+=====================

--- a/examples/image_volume/image_volume_ray.py
+++ b/examples/image_volume/image_volume_ray.py
@@ -1,0 +1,24 @@
+"""
+Volume Ray mode
+===============
+
+View a volume, uses the fly controller by default so you can fly around the scene using WASD keys and the mouse:
+https://docs.pygfx.org/stable/_autosummary/controllers/pygfx.controllers.FlyController.html#pygfx.controllers.FlyController
+"""
+
+# test_example = false
+# sphinx_gallery_pygfx_docs = 'screenshot'
+
+import numpy as np
+import fastplotlib as fpl
+import imageio.v3 as iio
+
+voldata = iio.imread("imageio:stent.npz").astype(np.float32)
+
+fig = fpl.Figure(cameras="3d", size=(700, 560))
+
+fig[0, 0].add_image_volume(voldata)
+
+fig.show()
+
+fpl.loop.run()

--- a/examples/tests/testutils.py
+++ b/examples/tests/testutils.py
@@ -18,6 +18,7 @@ diffs_dir = examples_dir / "diffs"
 # examples live in themed sub-folders
 example_globs = [
     "image/*.py",
+    "image_volume/*.py",
     "image_widget/*.py",
     "heatmap/*.py",
     "scatter/*.py",

--- a/fastplotlib/graphics/__init__.py
+++ b/fastplotlib/graphics/__init__.py
@@ -2,6 +2,7 @@ from ._base import Graphic
 from .line import LineGraphic
 from .scatter import ScatterGraphic
 from .image import ImageGraphic
+from .image_volume import ImageVolumeGraphic
 from .text import TextGraphic
 from .line_collection import LineCollection, LineStack
 
@@ -10,6 +11,7 @@ __all__ = [
     "LineGraphic",
     "ScatterGraphic",
     "ImageGraphic",
+    "ImageVolumeGraphic",
     "TextGraphic",
     "LineCollection",
     "LineStack",

--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -53,13 +53,6 @@ class Graphic:
     _features: dict[str, type] = dict()
 
     def __init_subclass__(cls, **kwargs):
-        # set the type of the graphic in lower case like "image", "line_collection", etc.
-        cls.type = (
-            cls.__name__.lower()
-            .replace("graphic", "")
-            .replace("collection", "_collection")
-            .replace("stack", "_stack")
-        )
 
         # set of all features
         cls._features = {

--- a/fastplotlib/graphics/features/_image_volume.py
+++ b/fastplotlib/graphics/features/_image_volume.py
@@ -1,0 +1,172 @@
+from itertools import product
+
+from math import ceil
+
+import numpy as np
+
+import pygfx
+from ._base import GraphicFeature, GraphicFeatureEvent, block_reentrance
+
+from ...utils import (
+    make_colors,
+    get_cmap_texture,
+)
+
+
+class TextureArray3D(GraphicFeature):
+    """
+    Manages an array of 3D Textures representing chunks of an image volume.
+
+    Creates multiple pygfx.Texture objects based on the GPU's max texture dimension limit.
+    """
+    event_info_spec = [
+        {
+            "dict key": "key",
+            "type": "slice, index, numpy-like fancy index",
+            "description": "key at which image data was sliced/fancy indexed",
+        },
+        {
+            "dict key": "value",
+            "type": "np.ndarray | float",
+            "description": "new data values",
+        },
+    ]
+
+    def __init__(self, data, isolated_buffer: bool = True):
+        super().__init__()
+
+        data = self._fix_data(data)
+
+        shared = pygfx.renderers.wgpu.get_shared()
+        self._texture_limit_3d = shared.device.limits["max-texture-dimension-3d"]
+
+        if isolated_buffer:
+            # useful if data is read-only, example: memmaps
+            self._value = np.zeros(data.shape, dtype=data.dtype)
+            self.value[:] = data[:]
+        else:
+            # user's input array is used as the buffer
+            self._value = data
+
+        # data start indices for each Texture
+        self._row_indices = np.arange(
+            0,
+            ceil(self.value.shape[0] / self._texture_limit_3d) * self._texture_limit_3d,
+            self._texture_limit_3d,
+        )
+        self._col_indices = np.arange(
+            0,
+            ceil(self.value.shape[1] / self._texture_limit_3d) * self._texture_limit_3d,
+            self._texture_limit_3d,
+        )
+
+        self._col_indices = np.arange(
+            0,
+            ceil(self.value.shape[1] / self._texture_limit_3d) * self._texture_limit_3d,
+            self._texture_limit_3d,
+        )
+
+        # buffer will be an array of textures
+        self._buffer: np.ndarray[pygfx.Texture] = np.empty(
+            shape=(self.row_indices.size, self.col_indices.size), dtype=object
+        )
+
+        self._iter = None
+
+        # iterate through each chunk of passed `data`
+        # create a pygfx.Texture from this chunk
+        for _, buffer_index, data_slice in self:
+            texture = pygfx.Texture(self.value[data_slice], dim=2)
+
+            self.buffer[buffer_index] = texture
+
+        self._shared: int = 0
+
+    @property
+    def value(self) -> np.ndarray:
+        return self._value
+
+    def set_value(self, graphic, value):
+        self[:] = value
+
+    @property
+    def buffer(self) -> np.ndarray[pygfx.Texture]:
+        return self._buffer
+
+    @property
+    def row_indices(self) -> np.ndarray:
+        """
+        row indices that are used to chunk the big data array
+        into individual Textures on the GPU
+        """
+        return self._row_indices
+
+    @property
+    def col_indices(self) -> np.ndarray:
+        """
+        column indices that are used to chunk the big data array
+        into individual Textures on the GPU
+        """
+        return self._col_indices
+
+    @property
+    def shared(self) -> int:
+        return self._shared
+
+    def _fix_data(self, data):
+        if data.ndim not in (2, 3):
+            raise ValueError(
+                "image data must be 2D with or without an RGB(A) dimension, i.e. "
+                "it must be of shape [rows, cols], [rows, cols, 3] or [rows, cols, 4]"
+            )
+
+        # let's just cast to float32 always
+        return data.astype(np.float32)
+
+    def __iter__(self):
+        self._iter = product(enumerate(self.row_indices), enumerate(self.col_indices))
+        return self
+
+    def __next__(self) -> tuple[pygfx.Texture, tuple[int, int], tuple[slice, slice]]:
+        """
+        Iterate through each Texture within the texture array
+
+        Returns
+        -------
+        Texture, tuple[int, int], tuple[slice, slice]
+            | Texture: pygfx.Texture
+            | tuple[int, int]: chunk index, i.e corresponding index of ``self.buffer`` array
+            | tuple[slice, slice]: data slice of big array in this chunk and Texture
+        """
+        (chunk_row, data_row_start), (chunk_col, data_col_start) = next(self._iter)
+
+        # indices for to self.buffer for this chunk
+        chunk_index = (chunk_row, chunk_col)
+
+        # stop indices of big data array for this chunk
+        row_stop = min(self.value.shape[0], data_row_start + self._texture_limit_3d)
+        col_stop = min(self.value.shape[1], data_col_start + self._texture_limit_3d)
+
+        # row and column slices that slice the data for this chunk from the big data array
+        data_slice = (slice(data_row_start, row_stop), slice(data_col_start, col_stop))
+
+        # texture for this chunk
+        texture = self.buffer[chunk_index]
+
+        return texture, chunk_index, data_slice
+
+    def __getitem__(self, item):
+        return self.value[item]
+
+    @block_reentrance
+    def __setitem__(self, key, value):
+        self.value[key] = value
+
+        for texture in self.buffer.ravel():
+            texture.update_range((0, 0, 0), texture.size)
+
+        event = GraphicFeatureEvent("data", info={"key": key, "value": value})
+        self._call_event_handlers(event)
+
+    def __len__(self):
+        return self.buffer.size

--- a/fastplotlib/graphics/image.py
+++ b/fastplotlib/graphics/image.py
@@ -101,10 +101,10 @@ class ImageGraphic(Graphic):
             | shape must be ``[n_rows, n_cols]``, ``[n_rows, n_cols, 3]`` for RGB or ``[n_rows, n_cols, 4]`` for RGBA
 
         vmin: int, optional
-            minimum value for color scaling, calculated from data if not provided
+            minimum value for color scaling, estimated from data if not provided
 
         vmax: int, optional
-            maximum value for color scaling, calculated from data if not provided
+            maximum value for color scaling, estimated from data if not provided
 
         cmap: str, optional, default "plasma"
             colormap to use to display the data
@@ -129,8 +129,8 @@ class ImageGraphic(Graphic):
 
         world_object = pygfx.Group()
 
-        # texture array that manages the textures on the GPU for displaying this image
-        self._data = TextureArray(data, isolated_buffer=isolated_buffer)
+        # texture array that manages the multiple textures on the GPU that represent this image
+        self._data = TextureArray(data, dim=2, isolated_buffer=isolated_buffer)
 
         if (vmin is None) or (vmax is None):
             vmin, vmax = quick_min_max(data)
@@ -165,7 +165,7 @@ class ImageGraphic(Graphic):
         )
 
         # iterate through each texture chunk and create
-        # an _ImageTIle, offset the tile using the data indices
+        # an _ImageTile, offset the tile using the data indices
         for texture, chunk_index, data_slice in self._data:
 
             # create an ImageTile using the texture for this chunk

--- a/fastplotlib/graphics/image_volume.py
+++ b/fastplotlib/graphics/image_volume.py
@@ -1,0 +1,229 @@
+from typing import *
+
+import pygfx
+
+from ..utils import quick_min_max
+from ._base import Graphic
+from .features import (
+    TextureArray,
+    ImageCmap,
+    ImageVmin,
+    ImageVmax,
+    ImageInterpolation,
+    ImageCmapInterpolation,
+)
+
+
+class _VolumeTile(pygfx.Volume):
+    """
+    Similar to pygfx.Volume, only difference is that it modifies the pick_info
+    by adding the data row start indices that correspond to this chunk of the big Volume
+    """
+
+    def __init__(
+        self,
+        geometry,
+        material,
+        data_slice: tuple[slice, slice, slice],
+        chunk_index: tuple[int, int, int],
+        **kwargs,
+    ):
+        super().__init__(geometry, material, **kwargs)
+
+        self._data_slice = data_slice
+        self._chunk_index = chunk_index
+
+    def _wgpu_get_pick_info(self, pick_value):
+        pick_info = super()._wgpu_get_pick_info(pick_value)
+
+        data_row_start, data_col_start, data_z_start = (
+            self.data_slice[0].start,
+            self.data_slice[1].start,
+            self.data_slice[2].start,
+        )
+
+        # add the actual data row and col start indices
+        x, y, z = pick_info["index"]
+        x += data_col_start
+        y += data_row_start
+        z += data_z_start
+        pick_info["index"] = (x, y, z)
+
+        xp, yp, zp = pick_info["voxel_coord"]
+        xp += data_col_start
+        yp += data_row_start
+        zp += data_z_start
+        pick_info["voxel_coord"] = (xp, yp, zp)
+
+        # add row chunk and col chunk index to pick_info dict
+        return {
+            **pick_info,
+            "data_slice": self.data_slice,
+            "chunk_index": self.chunk_index,
+        }
+
+    @property
+    def data_slice(self) -> tuple[slice, slice, slice]:
+        return self._data_slice
+
+    @property
+    def chunk_index(self) -> tuple[int, int, int]:
+        return self._chunk_index
+
+
+class ImageVolumeGraphic(Graphic):
+    _features = {
+        "data": TextureArray,
+        "cmap": ImageCmap,
+        "vmin": ImageVmin,
+        "vmax": ImageVmax,
+        "interpolation": ImageInterpolation,
+        "cmap_interpolation": ImageCmapInterpolation,
+    }
+
+    def __init__(
+            self,
+            data: Any,
+            mode: str = "ray",
+            vmin: int = None,
+            vmax: int = None,
+            cmap: str = "plasma",
+            interpolation: str = "nearest",
+            cmap_interpolation: str = "linear",
+            isolated_buffer: bool = True,
+            **kwargs,
+    ):
+        valid_modes = ["basic", "ray", "slice", "iso", "mip", "minip"]
+        if mode not in valid_modes:
+            raise ValueError(f"invalid mode specified: {mode}, valid modes are: {valid_modes}")
+
+        super().__init__(**kwargs)
+
+        world_object = pygfx.Group()
+
+        # texture array that manages the textures on the GPU that represent this image volume
+        self._data = TextureArray(data, dim=3, isolated_buffer=isolated_buffer)
+
+        if (vmin is None) or (vmax is None):
+            vmin, vmax = quick_min_max(data)
+
+        # other graphic features
+        self._vmin = ImageVmin(vmin)
+        self._vmax = ImageVmax(vmax)
+
+        self._interpolation = ImageInterpolation(interpolation)
+
+        # TODO: I'm assuming RGB volume images aren't supported???
+        # use TextureMap for grayscale images
+        self._cmap = ImageCmap(cmap)
+        self._cmap_interpolation = ImageCmapInterpolation(cmap_interpolation)
+
+        _map = pygfx.TextureMap(
+            self._cmap.texture,
+            filter=self._cmap_interpolation.value,
+            wrap="clamp-to-edge",
+        )
+
+        material_cls = getattr(pygfx, f"Volume{mode.capitalize()}Material")
+
+        # TODO: graphic features for the various material properties
+        self._material = material_cls(
+            clim=(self._vmin.value, self._vmax.value),
+            map=_map,
+            interpolation=self._interpolation.value,
+            pick_write=True,
+        )
+
+        # iterate through each texture chunk and create
+        # a _VolumeTile, offset the tile using the data indices
+        for texture, chunk_index, data_slice in self._data:
+            # create a _VolumeTile using the texture for this chunk
+            vol = _VolumeTile(
+                geometry=pygfx.Geometry(grid=texture),
+                material=self._material,
+                data_slice=data_slice,  # used to parse pick_info
+                chunk_index=chunk_index,
+            )
+
+            # row and column start index for this chunk
+            data_row_start = data_slice[0].start
+            data_col_start = data_slice[1].start
+            data_z_start = data_slice[2].start
+
+            # offset tile position using the indices from the big data array
+            # that correspond to this chunk
+            vol.world.x = data_col_start
+            vol.world.y = data_row_start
+            vol.world.z = data_z_start
+
+            world_object.add(vol)
+
+        self._set_world_object(world_object)
+
+    @property
+    def data(self) -> TextureArray:
+        """Get or set the image data"""
+        return self._data
+
+    @data.setter
+    def data(self, data):
+        self._data[:] = data
+
+    @property
+    def cmap(self) -> str:
+        """colormap name"""
+        return self._cmap.value
+
+    @cmap.setter
+    def cmap(self, name: str):
+        self._cmap.set_value(self, name)
+
+    @property
+    def vmin(self) -> float:
+        """lower contrast limit"""
+        return self._vmin.value
+
+    @vmin.setter
+    def vmin(self, value: float):
+        self._vmin.set_value(self, value)
+
+    @property
+    def vmax(self) -> float:
+        """upper contrast limit"""
+        return self._vmax.value
+
+    @vmax.setter
+    def vmax(self, value: float):
+        self._vmax.set_value(self, value)
+
+    @property
+    def interpolation(self) -> str:
+        """image data interpolation method"""
+        return self._interpolation.value
+
+    @interpolation.setter
+    def interpolation(self, value: str):
+        self._interpolation.set_value(self, value)
+
+    @property
+    def cmap_interpolation(self) -> str:
+        """cmap interpolation method"""
+        return self._cmap_interpolation.value
+
+    @cmap_interpolation.setter
+    def cmap_interpolation(self, value: str):
+        self._cmap_interpolation.set_value(self, value)
+
+    def reset_vmin_vmax(self):
+        """
+        Reset the vmin, vmax by estimating it from the data
+
+        Returns
+        -------
+        None
+
+        """
+
+        vmin, vmax = quick_min_max(self._data.value)
+        self.vmin = vmin
+        self.vmax = vmax

--- a/fastplotlib/layouts/_graphic_methods_mixin.py
+++ b/fastplotlib/layouts/_graphic_methods_mixin.py
@@ -32,7 +32,7 @@ class GraphicMethodsMixin:
         interpolation: str = "nearest",
         cmap_interpolation: str = "linear",
         isolated_buffer: bool = True,
-        **kwargs,
+        **kwargs
     ) -> ImageGraphic:
         """
 
@@ -45,10 +45,10 @@ class GraphicMethodsMixin:
             | shape must be ``[n_rows, n_cols]``, ``[n_rows, n_cols, 3]`` for RGB or ``[n_rows, n_cols, 4]`` for RGBA
 
         vmin: int, optional
-            minimum value for color scaling, calculated from data if not provided
+            minimum value for color scaling, estimated from data if not provided
 
         vmax: int, optional
-            maximum value for color scaling, calculated from data if not provided
+            maximum value for color scaling, estimated from data if not provided
 
         cmap: str, optional, default "plasma"
             colormap to use to display the data
@@ -78,7 +78,35 @@ class GraphicMethodsMixin:
             interpolation,
             cmap_interpolation,
             isolated_buffer,
-            **kwargs,
+            **kwargs
+        )
+
+    def add_image_volume(
+        self,
+        data: Any,
+        mode: str = "ray",
+        vmin: int = None,
+        vmax: int = None,
+        cmap: str = "plasma",
+        interpolation: str = "nearest",
+        cmap_interpolation: str = "linear",
+        isolated_buffer: bool = True,
+        **kwargs
+    ) -> ImageVolumeGraphic:
+        """
+        None
+        """
+        return self._create_graphic(
+            ImageVolumeGraphic,
+            data,
+            mode,
+            vmin,
+            vmax,
+            cmap,
+            interpolation,
+            cmap_interpolation,
+            isolated_buffer,
+            **kwargs
         )
 
     def add_line_collection(
@@ -96,7 +124,7 @@ class GraphicMethodsMixin:
         metadatas: Union[Sequence[Any], numpy.ndarray] = None,
         isolated_buffer: bool = True,
         kwargs_lines: list[dict] = None,
-        **kwargs,
+        **kwargs
     ) -> LineCollection:
         """
 
@@ -169,7 +197,7 @@ class GraphicMethodsMixin:
             metadatas,
             isolated_buffer,
             kwargs_lines,
-            **kwargs,
+            **kwargs
         )
 
     def add_line(
@@ -183,7 +211,7 @@ class GraphicMethodsMixin:
         cmap_transform: Union[numpy.ndarray, Iterable] = None,
         isolated_buffer: bool = True,
         size_space: str = "screen",
-        **kwargs,
+        **kwargs
     ) -> LineGraphic:
         """
 
@@ -234,7 +262,7 @@ class GraphicMethodsMixin:
             cmap_transform,
             isolated_buffer,
             size_space,
-            **kwargs,
+            **kwargs
         )
 
     def add_line_stack(
@@ -253,7 +281,7 @@ class GraphicMethodsMixin:
         separation: float = 10.0,
         separation_axis: str = "y",
         kwargs_lines: list[dict] = None,
-        **kwargs,
+        **kwargs
     ) -> LineStack:
         """
 
@@ -334,7 +362,7 @@ class GraphicMethodsMixin:
             separation,
             separation_axis,
             kwargs_lines,
-            **kwargs,
+            **kwargs
         )
 
     def add_scatter(
@@ -349,7 +377,7 @@ class GraphicMethodsMixin:
         sizes: Union[float, numpy.ndarray, Iterable[float]] = 1,
         uniform_size: bool = False,
         size_space: str = "screen",
-        **kwargs,
+        **kwargs
     ) -> ScatterGraphic:
         """
 
@@ -409,7 +437,7 @@ class GraphicMethodsMixin:
             sizes,
             uniform_size,
             size_space,
-            **kwargs,
+            **kwargs
         )
 
     def add_text(
@@ -422,7 +450,7 @@ class GraphicMethodsMixin:
         screen_space: bool = True,
         offset: tuple[float] = (0, 0, 0),
         anchor: str = "middle-center",
-        **kwargs,
+        **kwargs
     ) -> TextGraphic:
         """
 
@@ -473,5 +501,5 @@ class GraphicMethodsMixin:
             screen_space,
             offset,
             anchor,
-            **kwargs,
+            **kwargs
         )

--- a/fastplotlib/utils/functions.py
+++ b/fastplotlib/utils/functions.py
@@ -269,20 +269,21 @@ def make_colors_dict(labels: Sequence, cmap: str, **kwargs) -> OrderedDict:
 
 def quick_min_max(data: np.ndarray, max_size=1e6) -> tuple[float, float]:
     """
-    Adapted from pyqtgraph.ImageView.
-    Estimate the min/max values of *data* by subsampling.
+    Estimate the (min, max) values of data array by subsampling.
+
+    Also supports array-like data types may have a `min` and `max` property that provides a pre-calculated (min, max).
 
     Parameters
     ----------
-    data: np.ndarray or array-like with `min` and `max` attributes
+    data: np.ndarray or array-like
 
     max_size : int, optional
-        largest array size allowed in the subsampled array. Default is 1e6.
+        subsamples data array to this max size
 
     Returns
     -------
     (float, float)
-        (min, max)
+        (min, max) estimate
     """
 
     if hasattr(data, "min") and hasattr(data, "max"):


### PR DESCRIPTION
actually going to merge it this time

- [ ] `TextureArrays` supports 3D textures
- [ ] implement simple `ImageVolumeGraphic`
- [ ] implement graphic features for all the different volume materials
- [ ] examples
    - [ ] basic
    - [ ] 3D video, maybe generated calcium toy data?
    - [ ] 2D video over time, maybe from the calcium example I added to imageio
    - [ ] other toy data, does sklearn have any relevant ones?
- [ ] fix some typos in `graphics.image`
- [ ] `scripts/generate_add_graphic_methods.py` is better, removed `Graphic.type` attribute which was only used in the generate mixin script and use regex instead to create the `add_<graphic>` method names.
- [ ] tests, screenshots, API, new graphic, TextureArray for 2d and 3d, and any new graphic features.
- [ ] improve docstring for quick_min_max()

@almarklein are RGB volumes supported? Is it even a thing? 

selector tools for slicing, cube slicing, etc., non-orthogonal slicing to come later
