### PR TITLE
Improve hover color behavior for selectors

### DIFF
--- a/fastplotlib/graphics/selectors/_base_selector.py
+++ b/fastplotlib/graphics/selectors/_base_selector.py
@@ -263,7 +263,6 @@ class BaseSelector(Graphic):
 
         self._move_start(event_source, ev)
 
-
     def _move_start(self, event_source: WorldObject, ev):
         """
         Called on "pointer_down" events


### PR DESCRIPTION
Ref #781

I noticed that the color of the selector was flickering during motion, as the mouse enters and exits the object. This PR freezes the color while `._moving`, keeping track of color changes in a dict, and then applying that dict when the moving is done.

Notice how the corner vertex becomes highlighted as the mouse is released after dragging the edge:

https://github.com/user-attachments/assets/5f5db53c-cccf-43f5-8859-f1dc1589f8cc

