### PR TITLE
No ndim for iw

### DIFF
--- a/fastplotlib/widgets/image_widget/_widget.py
+++ b/fastplotlib/widgets/image_widget/_widget.py
@@ -895,6 +895,11 @@ class ImageWidget:
             )
         # check all arrays
         for i, (new_array, current_array) in enumerate(zip(new_data, self._data)):
+
+            # if we don't know the ndim, we can get it from the shape
+            if not hasattr(new_array, "ndim"):
+                new_array.ndim = len(new_array.shape)
+
             if new_array.ndim != current_array.ndim:
                 raise ValueError(
                     f"new data ndim {new_array.ndim} at index {i} "

--- a/fastplotlib/widgets/image_widget/_widget.py
+++ b/fastplotlib/widgets/image_widget/_widget.py
@@ -38,7 +38,7 @@ def _is_arraylike(obj) -> bool:
     Checks if the object is array-like.
     For now just checks if obj has `__getitem__()`
     """
-    for attr in ["__getitem__", "shape", "ndim"]:
+    for attr in ["__getitem__", "shape"]:
         if not hasattr(obj, attr):
             return False
 


### PR DESCRIPTION
Dont think we need ndim for image widgets. Was just using some suite2p binary files that didn't pass `_is_array_like()` because it didn't have ndim. Will test if you dont think its stupid