### PR TITLE
coerce dtype=np.int64 for np.prod calls in subsample

### DIFF
--- a/fastplotlib/utils/functions.py
+++ b/fastplotlib/utils/functions.py
@@ -455,11 +455,11 @@ def subsample_array(
     np.ndarray
         subsample of the input array
     """
-    if np.prod(arr.shape) <= max_size:
+    if np.prod(arr.shape, dtype=np.int64) <= max_size:
         return arr[:]  # no need to subsample if already below the threshold
 
     # get factor by which to divide all dims
-    f = np.power((np.prod(arr.shape) / max_size), 1.0 / arr.ndim)
+    f = np.power((np.prod(arr.shape, dtype=np.int64) / max_size), 1.0 / arr.ndim)
 
     # new shape for subsampled array
     ns = np.floor(np.array(arr.shape) / f).clip(min=1)

--- a/fastplotlib/utils/functions.py
+++ b/fastplotlib/utils/functions.py
@@ -455,18 +455,19 @@ def subsample_array(
     np.ndarray
         subsample of the input array
     """
-    if np.prod(arr.shape, dtype=np.int64) <= max_size:
+    full_shape = np.array(arr.shape, dtype=np.uint64)
+    if np.prod(full_shape) <= max_size:
         return arr[:]  # no need to subsample if already below the threshold
 
     # get factor by which to divide all dims
-    f = np.power((np.prod(arr.shape, dtype=np.int64) / max_size), 1.0 / arr.ndim)
+    f = np.power((np.prod(full_shape) / max_size), 1.0 / arr.ndim)
 
     # new shape for subsampled array
-    ns = np.floor(np.array(arr.shape) / f).clip(min=1)
+    ns = np.floor(np.array(full_shape) / f).clip(min=1)
 
     # get the step size for the slices
     slices = list(
-        slice(None, None, int(s)) for s in np.floor(arr.shape / ns).astype(int)
+        slice(None, None, int(s)) for s in np.floor(full_shape / ns).astype(int)
     )
 
     # ignore dims e.g. RGB, which we don't want to downsample

--- a/fastplotlib/utils/functions.py
+++ b/fastplotlib/utils/functions.py
@@ -465,7 +465,7 @@ def subsample_array(
     ns = np.floor(np.array(arr.shape) / f).clip(min=1)
 
     # get the step size for the slices
-    slices = tuple(
+    slices = list(
         slice(None, None, int(s)) for s in np.floor(arr.shape / ns).astype(int)
     )
 


### PR DESCRIPTION
Some of my datasets are overflowing during histogram calculation. 

```python
raw_scan.shape
Out[1]: (5632, 14, 448, 448)
np.prod(raw_scan.shape)
Out[2]: -1354760192
np.prod(raw_scan.shape, dtype=np.int64)
Out[3]: 15825108992
```

Also, `ignore_dims` won't work due to tuple item assignment. Changed that to a list