### PR TITLE
Reference spaces

### DIFF
--- a/examples/reference_spaces/line_scales.py
+++ b/examples/reference_spaces/line_scales.py
@@ -1,0 +1,24 @@
+import numpy as np
+import fastplotlib as fpl
+
+
+xs = np.linspace(0, 10 * np.pi, 1000)
+ys = np.sin(xs)
+
+ys100 = ys * 1000
+
+l1 = np.column_stack([xs, ys])
+l2 = np.column_stack([xs, ys100])
+
+fig = fpl.Figure(size=(500, 400))
+
+fig[0, 0].add_line(l1)
+fig.show(maintain_aspect=False)
+fig[0, 0].auto_scale(zoom=0.4)
+
+rs = fig[0, 0].add_reference_space(scale=(1, 500, 1))
+l2 = fig[0, 0].add_line(l2, reference_space=rs, colors="r")
+l2.add_axes(rs)
+l2.axes.y.line.material.color = "r"
+
+fpl.loop.run()

--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -447,15 +447,15 @@ class Graphic:
     def axes(self) -> Axes:
         return self._axes
 
-    def add_axes(self):
+    def add_axes(self, reference_frame):
         """Add axes onto this Graphic"""
         if self._axes is not None:
             raise AttributeError("Axes already added onto this graphic")
 
-        self._axes = Axes(self._plot_area, offset=self.offset, grids=False)
+        self._axes = Axes(reference_frame, offset=self.offset, grids=False)
         self._axes.world_object.local.rotation = self.world_object.local.rotation
 
-        self._plot_area.scene.add(self.axes.world_object)
+        reference_frame.scene.add(self.axes.world_object)
         self._axes.update_using_bbox(self.world_object.get_world_bounding_box())
 
     @property

--- a/fastplotlib/layouts/_graphic_methods_mixin.py
+++ b/fastplotlib/layouts/_graphic_methods_mixin.py
@@ -15,11 +15,16 @@ class GraphicMethodsMixin:
         else:
             center = False
 
+        if "reference_space" in kwargs.keys():
+            reference_space = kwargs.pop("reference_space")
+        else:
+            reference_space = 0
+
         if "name" in kwargs.keys():
             self._check_graphic_name_exists(kwargs["name"])
 
         graphic = graphic_class(*args, **kwargs)
-        self.add_graphic(graphic, center=center)
+        self.add_graphic(graphic, center=center, reference_space=reference_space)
 
         return graphic
 
@@ -32,7 +37,7 @@ class GraphicMethodsMixin:
         interpolation: str = "nearest",
         cmap_interpolation: str = "linear",
         isolated_buffer: bool = True,
-        **kwargs,
+        **kwargs
     ) -> ImageGraphic:
         """
 
@@ -78,7 +83,7 @@ class GraphicMethodsMixin:
             interpolation,
             cmap_interpolation,
             isolated_buffer,
-            **kwargs,
+            **kwargs
         )
 
     def add_line_collection(
@@ -96,7 +101,7 @@ class GraphicMethodsMixin:
         metadatas: Union[Sequence[Any], numpy.ndarray] = None,
         isolated_buffer: bool = True,
         kwargs_lines: list[dict] = None,
-        **kwargs,
+        **kwargs
     ) -> LineCollection:
         """
 
@@ -169,7 +174,7 @@ class GraphicMethodsMixin:
             metadatas,
             isolated_buffer,
             kwargs_lines,
-            **kwargs,
+            **kwargs
         )
 
     def add_line(
@@ -183,7 +188,7 @@ class GraphicMethodsMixin:
         cmap_transform: Union[numpy.ndarray, Iterable] = None,
         isolated_buffer: bool = True,
         size_space: str = "screen",
-        **kwargs,
+        **kwargs
     ) -> LineGraphic:
         """
 
@@ -234,7 +239,7 @@ class GraphicMethodsMixin:
             cmap_transform,
             isolated_buffer,
             size_space,
-            **kwargs,
+            **kwargs
         )
 
     def add_line_stack(
@@ -253,7 +258,7 @@ class GraphicMethodsMixin:
         separation: float = 10.0,
         separation_axis: str = "y",
         kwargs_lines: list[dict] = None,
-        **kwargs,
+        **kwargs
     ) -> LineStack:
         """
 
@@ -334,7 +339,7 @@ class GraphicMethodsMixin:
             separation,
             separation_axis,
             kwargs_lines,
-            **kwargs,
+            **kwargs
         )
 
     def add_scatter(
@@ -349,7 +354,7 @@ class GraphicMethodsMixin:
         sizes: Union[float, numpy.ndarray, Iterable[float]] = 1,
         uniform_size: bool = False,
         size_space: str = "screen",
-        **kwargs,
+        **kwargs
     ) -> ScatterGraphic:
         """
 
@@ -409,7 +414,7 @@ class GraphicMethodsMixin:
             sizes,
             uniform_size,
             size_space,
-            **kwargs,
+            **kwargs
         )
 
     def add_text(
@@ -422,7 +427,7 @@ class GraphicMethodsMixin:
         screen_space: bool = True,
         offset: tuple[float] = (0, 0, 0),
         anchor: str = "middle-center",
-        **kwargs,
+        **kwargs
     ) -> TextGraphic:
         """
 
@@ -473,5 +478,5 @@ class GraphicMethodsMixin:
             screen_space,
             offset,
             anchor,
-            **kwargs,
+            **kwargs
         )

--- a/fastplotlib/layouts/_reference_space.py
+++ b/fastplotlib/layouts/_reference_space.py
@@ -1,0 +1,90 @@
+import numpy as np
+
+import pygfx
+from pylinalg import vec_transform, vec_unproject
+
+from ..graphics import Graphic
+
+
+class ReferenceSpace:
+    def __init__(
+            self,
+            scene: pygfx.Scene,
+            camera: pygfx.Camera,
+            controller: pygfx.Controller,
+            viewport: pygfx.Viewport,
+            name: str | None = None,
+    ):
+        self._scene = scene
+        self._camera = camera
+        self._controller = controller
+        self.viewport = viewport
+        self._name = name
+
+        self._graphics: list[Graphic] = list()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def scene(self) -> pygfx.Scene:
+        return self._scene
+
+    @property
+    def camera(self) -> pygfx.Camera:
+        return self._camera
+
+    # @property
+    # def controller(self):
+        # same controller for all reference spaces in one PlotArea I think?
+        # Use key events to add or remove a camera from the PlotArea dynamically?
+        # pass
+
+    def auto_scale(self):
+        pass
+
+    def center(self):
+        pass
+
+    @property
+    def graphics(self) -> np.ndarray[Graphic]:
+        graphics = np.asarray(self._graphics)
+        graphics.flags.writeable = False
+        return graphics
+
+    def map_screen_to_world(
+        self, pos: tuple[float, float] | pygfx.PointerEvent, allow_outside: bool = False
+    ) -> np.ndarray | None:
+        """
+        Map screen position to world position
+
+        Parameters
+        ----------
+        pos: (float, float) | pygfx.PointerEvent
+            ``(x, y)`` screen coordinates, or ``pygfx.PointerEvent``
+
+        """
+        if isinstance(pos, pygfx.PointerEvent):
+            pos = pos.x, pos.y
+
+        if not allow_outside and not self.viewport.is_inside(*pos):
+            return None
+
+        vs = self.viewport.logical_size
+
+        # get position relative to viewport
+        pos_rel = (
+            pos[0] - self.viewport.rect[0],
+            pos[1] - self.viewport.rect[1],
+        )
+
+        # convert screen position to NDC
+        pos_ndc = (pos_rel[0] / vs[0] * 2 - 1, -(pos_rel[1] / vs[1] * 2 - 1), 0)
+
+        # get world position
+        pos_ndc += vec_transform(self.camera.world.position, self.camera.camera_matrix)
+        pos_world = vec_unproject(pos_ndc[:2], self.camera.camera_matrix)
+
+        # default z is zero for now
+        return np.array([*pos_world[:2], 0])

--- a/scripts/generate_add_graphic_methods.py
+++ b/scripts/generate_add_graphic_methods.py
@@ -19,6 +19,9 @@ modules = list()
 
 for name, obj in inspect.getmembers(graphics):
     if inspect.isclass(obj):
+        if obj.__name__ == "Graphic":
+            # skip base class
+            continue
         modules.append(obj)
 
 
@@ -42,10 +45,16 @@ def generate_add_graphics_methods():
     f.write("            center = kwargs.pop('center')\n")
     f.write("        else:\n")
     f.write("            center = False\n\n")
+
+    f.write("        if 'reference_space' in kwargs.keys():\n")
+    f.write("            reference_space = kwargs.pop('reference_space')\n")
+    f.write("        else:\n")
+    f.write("            reference_space = 0\n\n")
+
     f.write("        if 'name' in kwargs.keys():\n")
     f.write("            self._check_graphic_name_exists(kwargs['name'])\n\n")
     f.write("        graphic = graphic_class(*args, **kwargs)\n")
-    f.write("        self.add_graphic(graphic, center=center)\n\n")
+    f.write("        self.add_graphic(graphic, center=center, reference_space=reference_space)\n\n")
     f.write("        return graphic\n\n")
 
     for m in modules:


### PR DESCRIPTION
Proof of concept for reference spaces, implements ideas from #772 

There are two sine waves here but the red one is 3 orders or magnitude larger. The magenta y-axis indicates the values for the red sine data which ranges from [-1000, 1000] and the white axis ticks are for the white sine line which ranges from [-1, 1]

![image](https://github.com/user-attachments/assets/1e9480f2-7caf-42b7-a69d-5eb0c4d63302)

```python
import numpy as np
import fastplotlib as fpl


xs = np.linspace(0, 10 * np.pi, 1000)
ys = np.sin(xs)

ys100 = ys * 1000

l1 = np.column_stack([xs, ys])
l2 = np.column_stack([xs, ys100])

fig = fpl.Figure(size=(500, 400))

fig[0, 0].add_line(l1)
fig.show(maintain_aspect=False)
fig[0, 0].auto_scale(zoom=0.4)

rs = fig[0, 0].add_reference_space(scale=(1, 500, 1))
l2 = fig[0, 0].add_line(l2, reference_space=rs, colors="r")
l2.add_axes(rs)
l2.axes.y.line.material.color = "m"

fpl.loop.run()
```