### PR TITLE
docstring and docs cleanup, other misc small things

### DIFF
--- a/examples/controllers/specify_integers.py
+++ b/examples/controllers/specify_integers.py
@@ -24,14 +24,14 @@ ids = [
     [2, 0],
 ]
 
-names = [f"contr. id: {i}" for i in np.asarray(ids).ravel()]
-
 figure = fpl.Figure(
     shape=(2, 2),
     controller_ids=ids,
-    names=names,
     size=(700, 560),
 )
+
+for subplot, controller_id in zip(figure, np.asarray(ids).ravel()):
+    subplot.title = f"contr. id: {controller_id}"
 
 figure[0, 0].add_line(np.column_stack([xs, sine]))
 

--- a/examples/gridplot/README.rst
+++ b/examples/gridplot/README.rst
@@ -1,2 +1,2 @@
-GridPlot Examples
-=================
+Grid layout Examples
+====================

--- a/examples/gridplot/gridplot.py
+++ b/examples/gridplot/gridplot.py
@@ -1,8 +1,8 @@
 """
-GridPlot Simple
-===============
+Grid layout Simple
+==================
 
-Example showing simple 2x2 GridPlot with Standard images from imageio.
+Example showing simple 2x2 grid layout with standard images from imageio.
 """
 
 # test_example = true

--- a/examples/gridplot/gridplot_non_square.py
+++ b/examples/gridplot/gridplot_non_square.py
@@ -1,8 +1,8 @@
 """
-GridPlot Non-Square Example
-===========================
+Grid Layout 2
+=============
 
-Example showing simple 2x2 GridPlot with Standard images from imageio.
+Simple 2x2 grid layout Figure with standard images from imageio, one subplot is left empty
 """
 
 # test_example = true

--- a/examples/gridplot/gridplot_viewports_check.py
+++ b/examples/gridplot/gridplot_viewports_check.py
@@ -1,6 +1,6 @@
 """
-GridPlot test viewport rects
-============================
+Grid layout test viewport rects
+===============================
 
 Test figure to test that viewport rects are positioned correctly
 """

--- a/examples/gridplot/multigraphic_gridplot.py
+++ b/examples/gridplot/multigraphic_gridplot.py
@@ -1,8 +1,8 @@
 """
-Multi-Graphic GridPlot
-======================
+Multi-Graphic Grid layout
+=========================
 
-Example showing a Figure with multiple subplots and multiple graphic types.
+A Figure with multiple subplots and multiple graphic types.
 """
 
 # test_example = false

--- a/examples/misc/multiplot_animation.py
+++ b/examples/misc/multiplot_animation.py
@@ -2,7 +2,7 @@
 Multi-Subplot Image Update
 ==========================
 
-Example showing updating a multiple subplots with new random 512x512 data.
+Multiple subplots with an image that updates with new data on every render.
 """
 
 # test_example = false
@@ -27,7 +27,7 @@ figure[0,2]["rand-img"].cmap = "gray"
 figure[1,1]["rand-img"].cmap = "spring"
 
 # Define a function to update the image graphics with new data
-# add_animations will pass the gridplot to the animation function
+# add_animations will pass the figure to the animation function
 def update_data(f):
     for subplot in f:
         new_data = np.random.rand(512, 512)
@@ -37,7 +37,7 @@ def update_data(f):
 # add the animation function
 figure.add_animations(update_data)
 
-# show the gridplot
+# show the figure
 figure.show()
 
 

--- a/examples/notebooks/quickstart.ipynb
+++ b/examples/notebooks/quickstart.ipynb
@@ -463,7 +463,7 @@
    "id": "5694dca1-1041-4e09-a1da-85b293c5af47",
    "metadata": {},
    "source": [
-    "### RGB images are also supported\n",
+    "### RGB(A) images are supported\n",
     "\n",
     "`cmap` arguments are ignored for rgb images, but vmin vmax still works"
    ]
@@ -538,7 +538,7 @@
    "source": [
     "### Image updates\n",
     "\n",
-    "This examples show how you can define animation functions that run on every render cycle."
+    "This example shows how you can define animation functions that run on every render cycle."
    ]
   },
   {
@@ -620,7 +620,7 @@
    "id": "f226c9c2-8d0e-41ab-9ab9-1ae31fd91de5",
    "metadata": {},
    "source": [
-    "#### Keeping a reference to the Graphic instance, as shown above `image_graphic_instance`, is useful if you're creating something where you need flexibility in the naming of the graphics"
+    "#### Keeping a reference to the Graphic instance, as shown above `image_graphic_instance`, is useful if you're creating something where it is convenient to keep your own reference to a `Graphic`"
    ]
   },
   {
@@ -628,7 +628,7 @@
    "id": "d11fabb7-7c76-4e94-893d-80ed9ee3be3d",
    "metadata": {},
    "source": [
-    "### You can also use `ipywidgets.VBox` and `HBox` to stack plots. See the `subplot` notebooks for more automated subplotting"
+    "### You can also use `ipywidgets.VBox` and `HBox` to stack plots."
    ]
   },
   {
@@ -664,7 +664,7 @@
     "\n",
     "## 2D line plots\n",
     "\n",
-    "This example plots a sine wave, cosine wave, and ricker wavelet and demonstrates how **Graphic Features** can be modified by slicing!"
+    "This example plots a sine wave, cosine wave, and ricker wavelet and demonstrates how **Graphic Properties** can be modified by slicing!"
    ]
   },
   {
@@ -755,7 +755,7 @@
     "\n",
     "Set `maintain_aspect = False` on a camera, and then use the right mouse button and move the mouse to stretch and squeeze the view!\n",
     "\n",
-    "You can also click the **`1:1`** button to toggle this, or use `subplot.camera.maintain_aspect`"
+    "You can also click the **`⛶`** button to toggle this, or use `subplot.camera.maintain_aspect`"
    ]
   },
   {
@@ -763,7 +763,7 @@
    "id": "1651e965-f750-47ac-bf53-c23dae84cc98",
    "metadata": {},
    "source": [
-    "### reset the plot area"
+    "### reset the plot area camera"
    ]
   },
   {
@@ -783,7 +783,9 @@
    "id": "dcd68796-c190-4c3f-8519-d73b98ff6367",
    "metadata": {},
    "source": [
-    "## Graphic features support slicing! :D "
+    "## Graphic properties support slicing! :D\n",
+    "\n",
+    "Data, colors, and cmaps can often be sliced just like arrays to set or get values!"
    ]
   },
   {
@@ -811,7 +813,7 @@
    "id": "c9689887-cdf3-4a4d-948f-7efdb09bde4e",
    "metadata": {},
    "source": [
-    "## You can capture changes to a graphic feature as events"
+    "## Graphic properties are _evented_, so you can capture when they change"
    ]
   },
   {
@@ -1551,7 +1553,7 @@
     "    subplot.add_image(data, name=\"rand-img\")\n",
     "\n",
     "# Define a function to update the image graphics with new data\n",
-    "# add_animations will pass the gridplot to the animation function\n",
+    "# add_animations will pass the figure to the animation function\n",
     "def update_data(f):\n",
     "    for subplot in f:\n",
     "        new_data = np.random.rand(512, 512)\n",
@@ -1561,7 +1563,7 @@
     "# add the animation function\n",
     "figure_grid.add_animations(update_data)\n",
     "\n",
-    "# show the gridplot\n",
+    "# show the figure\n",
     "figure_grid.show()"
    ]
   },
@@ -1575,7 +1577,7 @@
     }
    },
    "source": [
-    "### Slicing GridPlot"
+    "### Slicing a grid layout to get subplots"
    ]
   },
   {
@@ -1605,7 +1607,7 @@
     }
    },
    "source": [
-    "You can get the graphics within a subplot, just like with simple `Plot`"
+    "You can get the graphics within a subplot"
    ]
   },
   {
@@ -1661,7 +1663,7 @@
     }
    },
    "source": [
-    "more slicing with `GridPlot`"
+    "more slicing with a `Figure` that has a grid layout"
    ]
   },
   {
@@ -1707,7 +1709,7 @@
    },
    "outputs": [],
    "source": [
-    "# these are really the same\n",
+    "# these are the same\n",
     "figure_grid[\"top-right-plot\"] is figure_grid[0, 2]"
    ]
   },
@@ -1749,7 +1751,7 @@
     }
    },
    "source": [
-    "## Figure subplot customization"
+    "## Figure subplot customization in a grid layout"
    ]
   },
   {
@@ -1776,13 +1778,13 @@
     "]\n",
     "\n",
     "\n",
-    "# you can give string names for each subplot within the gridplot\n",
+    "# you can give string names for each subplot within the figure\n",
     "names = [\n",
     "    [\"subplot0\", \"subplot1\", \"subplot2\"],\n",
     "    [\"subplot3\", \"subplot4\", \"subplot5\"]\n",
     "]\n",
     "\n",
-    "# Create the grid plot\n",
+    "# Create the figure\n",
     "figure_grid = fpl.Figure(\n",
     "    shape=shape,\n",
     "    controller_ids=controller_ids,\n",
@@ -1819,7 +1821,7 @@
     }
    },
    "source": [
-    "Indexing the gridplot to access subplots"
+    "Slicing/indexing the figure to get subplots"
    ]
   },
   {
@@ -1834,7 +1836,7 @@
    },
    "outputs": [],
    "source": [
-    "# can access subplot by name\n",
+    "# get subplot by name\n",
     "figure_grid[\"subplot0\"]"
    ]
   },
@@ -1850,7 +1852,7 @@
    },
    "outputs": [],
    "source": [
-    "# can access subplot by index\n",
+    "# or get subplot by index\n",
     "figure_grid[0, 0]"
    ]
   },
@@ -1864,7 +1866,7 @@
     }
    },
    "source": [
-    "**subplots also support indexing!**\n",
+    "**from before, remember subplots themselves also support slicing to get graphics within them!**\n",
     "\n",
     "this can be used to get graphics if they are named"
    ]
@@ -1883,6 +1885,17 @@
    "source": [
     "# can access graphic directly via name\n",
     "figure_grid[\"subplot0\"][\"rand-image\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87905450bdc0ec0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# or by their numerical index\n",
+    "figure_grid[\"subplot0\"].graphics[0]"
    ]
   },
   {
@@ -1911,7 +1924,7 @@
     }
    },
    "source": [
-    "positional indexing also works event if subplots have string names"
+    "positional indexing also works even if subplots have string names"
    ]
   },
   {

--- a/examples/scatter/scatter_size.py
+++ b/examples/scatter/scatter_size.py
@@ -2,7 +2,10 @@
 Scatter Plot Size
 =================
 
-Example showing point size change for scatter plot.
+Example that shows how to set scatter sizes in two different ways.
+
+One subplot uses a single scaler value for every point, and another subplot uses an array that defines the size for
+each individual scatter point.
 """
 
 # test_example = true
@@ -14,10 +17,10 @@ import fastplotlib as fpl
 # figure with 2 rows and 3 columns
 shape = (2, 1)
 
-# you can give string names for each subplot within the gridplot
+# you can give string names for each subplot within the figure
 names = [["scalar_size"], ["array_size"]]
 
-# Create the grid plot
+# Create the figure
 figure = fpl.Figure(shape=shape, names=names, size=(700, 560))
 
 # get y_values using sin function

--- a/fastplotlib/graphics/_positions_base.py
+++ b/fastplotlib/graphics/_positions_base.py
@@ -45,7 +45,11 @@ class PositionsGraphic(Graphic):
 
     @property
     def cmap(self) -> VertexCmap:
-        """Control the cmap, cmap transform, or cmap alpha"""
+        """
+        Control the cmap, cmap transform, or cmap alpha
+
+        For supported colormaps see the ``cmap`` library catalogue: https://cmap-docs.readthedocs.io/en/stable/catalog/
+        """
         return self._cmap
 
     @cmap.setter

--- a/fastplotlib/graphics/_positions_base.py
+++ b/fastplotlib/graphics/_positions_base.py
@@ -19,7 +19,7 @@ class PositionsGraphic(Graphic):
 
     @property
     def data(self) -> VertexPositions:
-        """Get or set the vertex positions data"""
+        """Get or set the graphic's data"""
         return self._data
 
     @data.setter
@@ -28,7 +28,7 @@ class PositionsGraphic(Graphic):
 
     @property
     def colors(self) -> VertexColors | pygfx.Color:
-        """Get or set the colors data"""
+        """Get or set the colors"""
         if isinstance(self._colors, VertexColors):
             return self._colors
 

--- a/fastplotlib/graphics/image.py
+++ b/fastplotlib/graphics/image.py
@@ -107,7 +107,8 @@ class ImageGraphic(Graphic):
             maximum value for color scaling, calculated from data if not provided
 
         cmap: str, optional, default "plasma"
-            colormap to use to display the data
+            colormap to use to display the data. For supported colormaps see the
+            ``cmap`` library catalogue: https://cmap-docs.readthedocs.io/en/stable/catalog/
 
         interpolation: str, optional, default "nearest"
             interpolation filter, one of "nearest" or "linear"
@@ -118,7 +119,8 @@ class ImageGraphic(Graphic):
         isolated_buffer: bool, default True
             If True, initialize a buffer with the same shape as the input data and then
             set the data, useful if the data arrays are ready-only such as memmaps.
-            If False, the input array is itself used as the buffer.
+            If False, the input array is itself used as the buffer - useful if the
+            array is large.
 
         kwargs:
             additional keyword arguments passed to Graphic
@@ -200,7 +202,11 @@ class ImageGraphic(Graphic):
 
     @property
     def cmap(self) -> str:
-        """colormap name"""
+        """
+        get or set the colormap
+
+        For supported colormaps see the ``cmap`` library catalogue: https://cmap-docs.readthedocs.io/en/stable/catalog/
+        """
         if self.data.value.ndim > 2:
             raise AttributeError("RGB(A) images do not have a colormap property")
         return self._cmap.value
@@ -231,7 +237,7 @@ class ImageGraphic(Graphic):
 
     @property
     def interpolation(self) -> str:
-        """image data interpolation method"""
+        """data interpolation method"""
         return self._interpolation.value
 
     @interpolation.setter
@@ -249,12 +255,7 @@ class ImageGraphic(Graphic):
 
     def reset_vmin_vmax(self):
         """
-        Reset the vmin, vmax by estimating it from the data
-
-        Returns
-        -------
-        None
-
+        Reset the vmin, vmax by estimating it from the data by subsampling.
         """
 
         vmin, vmax = quick_min_max(self._data.value)
@@ -262,18 +263,18 @@ class ImageGraphic(Graphic):
         self.vmax = vmax
 
     def add_linear_selector(
-        self, selection: int = None, axis: str = "x", padding: float = None, **kwargs
+        self, selection: int = None, axis: str = "x", **kwargs
     ) -> LinearSelector:
         """
         Adds a :class:`.LinearSelector`.
+
+        Selectors are just ``Graphic`` objects, so you can manage, remove, or delete them
+        from a plot area just like any other ``Graphic``.
 
         Parameters
         ----------
         selection: int, optional
             initial position of the selector
-
-        padding: float, optional
-            pad the length of the selector
 
         kwargs:
             passed to :class:`.LinearSelector`
@@ -333,8 +334,10 @@ class ImageGraphic(Graphic):
         **kwargs,
     ) -> LinearRegionSelector:
         """
-        Add a :class:`.LinearRegionSelector`. Selectors are just ``Graphic`` objects, so you can manage,
-        remove, or delete them from a plot area just like any other ``Graphic``.
+        Add a :class:`.LinearRegionSelector`.
+
+        Selectors are just ``Graphic`` objects, so you can manage, remove, or delete them
+        from a plot area just like any other ``Graphic``.
 
         Parameters
         ----------
@@ -353,7 +356,6 @@ class ImageGraphic(Graphic):
         Returns
         -------
         LinearRegionSelector
-            linear selection graphic
 
         """
 
@@ -408,13 +410,16 @@ class ImageGraphic(Graphic):
         **kwargs,
     ) -> RectangleSelector:
         """
-        Add a :class:`.RectangleSelector`. Selectors are just ``Graphic`` objects, so you can manage,
-        remove, or delete them from a plot area just like any other ``Graphic``.
+        Add a :class:`.RectangleSelector`.
+
+        Selectors are just ``Graphic`` objects, so you can manage, remove, or delete them
+        from a plot area just like any other ``Graphic``.
 
         Parameters
         ----------
         selection: (float, float, float, float), optional
             initial (xmin, xmax, ymin, ymax) of the selection
+
         """
         # default selection is 25% of the diagonal
         if selection is None:

--- a/fastplotlib/graphics/image.py
+++ b/fastplotlib/graphics/image.py
@@ -286,21 +286,11 @@ class ImageGraphic(Graphic):
         """
 
         if axis == "x":
-            size = self._data.value.shape[0]
-            center = size / 2
             limits = (0, self._data.value.shape[1])
         elif axis == "y":
-            size = self._data.value.shape[1]
-            center = size / 2
             limits = (0, self._data.value.shape[0])
         else:
             raise ValueError("`axis` must be one of 'x' | 'y'")
-
-        # default padding is 25% the height or width of the image
-        if padding is None:
-            size *= 1.25
-        else:
-            size += padding
 
         if selection is None:
             selection = limits[0]

--- a/fastplotlib/graphics/line.py
+++ b/fastplotlib/graphics/line.py
@@ -126,7 +126,7 @@ class LineGraphic(PositionsGraphic):
 
     @property
     def thickness(self) -> float:
-        """line thickness"""
+        """get or set the line thickness"""
         return self._thickness.value
 
     @thickness.setter

--- a/fastplotlib/graphics/line.py
+++ b/fastplotlib/graphics/line.py
@@ -160,7 +160,7 @@ class LineGraphic(PositionsGraphic):
         """
 
         bounds_init, limits, size, center = self._get_linear_selector_init_args(
-            axis, padding
+            axis, padding=0
         )
 
         if selection is None:

--- a/fastplotlib/graphics/line.py
+++ b/fastplotlib/graphics/line.py
@@ -30,11 +30,11 @@ class LineGraphic(PositionsGraphic):
         self,
         data: Any,
         thickness: float = 2.0,
-        colors: str | np.ndarray | Iterable = "w",
+        colors: str | np.ndarray | Sequence = "w",
         uniform_color: bool = False,
         alpha: float = 1.0,
         cmap: str = None,
-        cmap_transform: np.ndarray | Iterable = None,
+        cmap_transform: np.ndarray | Sequence = None,
         isolated_buffer: bool = True,
         size_space: str = "screen",
         **kwargs,
@@ -45,14 +45,18 @@ class LineGraphic(PositionsGraphic):
         Parameters
         ----------
         data: array-like
-            Line data to plot, 2D must be of shape [n_points, 2], 3D must be of shape [n_points, 3]
+            Line data to plot. Can provide 1D, 2D, or a 3D data.
+
+            | If passing a 1D array, it is used to set the y-values and the x-values are generated as an integer range
+            from [0, data.size]
+            | 2D data must be of shape [n_points, 2]. 3D data must be of shape [n_points, 3]
 
         thickness: float, optional, default 2.0
             thickness of the line
 
         colors: str, array, or iterable, default "w"
             specify colors as a single human-readable string, a single RGBA array,
-            or an iterable of strings or RGBA arrays
+            or a Sequence (array, tuple, or list) of strings or RGBA arrays
 
         uniform_color: bool, default ``False``
             if True, uses a uniform buffer for the line color,
@@ -62,14 +66,15 @@ class LineGraphic(PositionsGraphic):
             alpha value for the colors
 
         cmap: str, optional
-            apply a colormap to the line instead of assigning colors manually, this
-            overrides any argument passed to "colors"
+            Apply a colormap to the line instead of assigning colors manually, this
+            overrides any argument passed to "colors". For supported colormaps see the
+            ``cmap`` library catalogue: https://cmap-docs.readthedocs.io/en/stable/catalog/
 
         cmap_transform: 1D array-like of numerical values, optional
             if provided, these values are used to map the colors from the cmap
 
         size_space: str, default "screen"
-            coordinate space in which the size is expressed ("screen", "world", "model")
+            coordinate space in which the thickness is expressed ("screen", "world", "model")
 
         **kwargs
             passed to Graphic
@@ -129,23 +134,21 @@ class LineGraphic(PositionsGraphic):
         self._thickness.set_value(self, value)
 
     def add_linear_selector(
-        self, selection: float = None, padding: float = 0.0, axis: str = "x", **kwargs
+        self, selection: float = None, axis: str = "x", **kwargs
     ) -> LinearSelector:
         """
-        Adds a linear selector.
+        Adds a :class:`.LinearSelector`.
 
-        Parameters
-        ----------
+        Selectors are just ``Graphic`` objects, so you can manage, remove, or delete them from a
+        plot area just like any other ``Graphic``.
+
         Parameters
         ----------
         selection: float, optional
-            selected point on the linear selector, computed from data if not provided
+            selected point on the linear selector, by default the first datapoint on the line.
 
         axis: str, default "x"
             axis that the selector resides on
-
-        padding: float, default 0.0
-            Extra padding to extend the linear selector along the orthogonal axis to make it easier to interact with.
 
         kwargs
             passed to :class:`.LinearSelector`
@@ -186,8 +189,10 @@ class LineGraphic(PositionsGraphic):
         **kwargs,
     ) -> LinearRegionSelector:
         """
-        Add a :class:`.LinearRegionSelector`. Selectors are just ``Graphic`` objects, so you can manage,
-        remove, or delete them from a plot area just like any other ``Graphic``.
+        Add a :class:`.LinearRegionSelector`.
+
+        Selectors are just ``Graphic`` objects, so you can manage, remove, or delete them from a
+        plot area just like any other ``Graphic``.
 
         Parameters
         ----------
@@ -243,8 +248,10 @@ class LineGraphic(PositionsGraphic):
         **kwargs,
     ) -> RectangleSelector:
         """
-        Add a :class:`.RectangleSelector`. Selectors are just ``Graphic`` objects, so you can manage,
-        remove, or delete them from a plot area just like any other ``Graphic``.
+        Add a :class:`.RectangleSelector`.
+
+        Selectors are just ``Graphic`` objects, so you can manage, remove, or delete them from a
+        plot area just like any other ``Graphic``.
 
         Parameters
         ----------

--- a/fastplotlib/graphics/line.py
+++ b/fastplotlib/graphics/line.py
@@ -46,7 +46,6 @@ class LineGraphic(PositionsGraphic):
         ----------
         data: array-like
             Line data to plot. Can provide 1D, 2D, or a 3D data.
-
             | If passing a 1D array, it is used to set the y-values and the x-values are generated as an integer range
             from [0, data.size]
             | 2D data must be of shape [n_points, 2]. 3D data must be of shape [n_points, 3]

--- a/fastplotlib/graphics/scatter.py
+++ b/fastplotlib/graphics/scatter.py
@@ -33,7 +33,7 @@ class ScatterGraphic(PositionsGraphic):
         cmap: str = None,
         cmap_transform: np.ndarray = None,
         isolated_buffer: bool = True,
-        sizes: float | np.ndarray | Iterable[float] = 1,
+        sizes: float | np.ndarray | Sequence[float] = 1,
         uniform_size: bool = False,
         size_space: str = "screen",
         **kwargs,
@@ -44,36 +44,38 @@ class ScatterGraphic(PositionsGraphic):
         Parameters
         ----------
         data: array-like
-            Scatter data to plot, 2D must be of shape [n_points, 2], 3D must be of shape [n_points, 3]
+            Scatter data to plot, Can provide 2D, or a 3D data. 2D data must be of shape [n_points, 2].
+            3D data must be of shape [n_points, 3]
 
-        colors: str, array, or iterable, default "w"
-            specify colors as a single human readable string, a single RGBA array,
-            or an iterable of strings or RGBA arrays
+        colors: str, array, tuple, list, Sequence, default "w"
+            specify colors as a single human-readable string, a single RGBA array,
+            or a Sequence (array, tuple, or list) of strings or RGBA arrays
 
         uniform_color: bool, default False
-            if True, uses a uniform buffer for the scatter point colors,
-            basically saves GPU VRAM when the entire line has a single color
+            if True, uses a uniform buffer for the scatter point colors. Useful if you need to
+            save GPU VRAM when all points have the same color.
 
         alpha: float, optional, default 1.0
             alpha value for the colors
 
         cmap: str, optional
             apply a colormap to the scatter instead of assigning colors manually, this
-            overrides any argument passed to "colors"
+            overrides any argument passed to "colors".  For supported colormaps see the
+            ``cmap`` library catalogue: https://cmap-docs.readthedocs.io/en/stable/catalog/
 
         cmap_transform: 1D array-like or list of numerical values, optional
             if provided, these values are used to map the colors from the cmap
 
         isolated_buffer: bool, default True
             whether the buffers should be isolated from the user input array.
-            Generally always ``True``, ``False`` is for rare advanced use.
+            Generally always ``True``, ``False`` is for rare advanced use if you have large arrays.
 
         sizes: float or iterable of float, optional, default 1.0
-            size of the scatter points
+            sizes of the scatter points
 
         uniform_size: bool, default False
-            if True, uses a uniform buffer for the scatter point sizes,
-            basically saves GPU VRAM when all scatter points are the same size
+            if True, uses a uniform buffer for the scatter point sizes. Useful if you need to
+            save GPU VRAM when all points have the same size.
 
         size_space: str, default "screen"
             coordinate space in which the size is expressed ("screen", "world", "model")

--- a/fastplotlib/graphics/selectors/_rectangle.py
+++ b/fastplotlib/graphics/selectors/_rectangle.py
@@ -83,13 +83,16 @@ class RectangleSelector(BaseSelector):
             if ``True``, the edges can be dragged to resize the selection
 
         fill_color: str, array, or tuple
-            fill color for the selector, passed to pygfx.Color
+            fill color for the selector as a str or RGBA array
 
         edge_color: str, array, or tuple
-            edge color for the selector, passed to pygfx.Color
+            edge color for the selector as a str or RGBA array
 
         edge_thickness: float, default 8
             edge thickness
+
+        vertex_color: str, array, or tuple
+            vertex color for the selector as a str or RGBA array
 
         arrow_keys_modifier: str
             modifier key that must be pressed to initiate movement using arrow keys, must be one of:

--- a/fastplotlib/graphics/text.py
+++ b/fastplotlib/graphics/text.py
@@ -43,10 +43,10 @@ class TextGraphic(Graphic):
         font_size: float | int, default 10
             font size
 
-        face_color: str or array, default "w"
+        face_color: str, array, list, tuple, default "w"
             str or RGBA array to set the color of the text
 
-        outline_color: str or array, default "w"
+        outline_color: str, array, list, tuple, default "w"
             str or RGBA array to set the outline color of the text
 
         outline_thickness: float, default 0
@@ -102,7 +102,7 @@ class TextGraphic(Graphic):
 
     @property
     def text(self) -> str:
-        """the text displayed"""
+        """get or set the text"""
         return self._text.value
 
     @text.setter
@@ -111,7 +111,7 @@ class TextGraphic(Graphic):
 
     @property
     def font_size(self) -> float | int:
-        """ "text font size"""
+        """get or set the font size"""
         return self._font_size.value
 
     @font_size.setter
@@ -120,7 +120,7 @@ class TextGraphic(Graphic):
 
     @property
     def face_color(self) -> pygfx.Color:
-        """text face color"""
+        """get or set the face color"""
         return self._face_color.value
 
     @face_color.setter
@@ -129,7 +129,7 @@ class TextGraphic(Graphic):
 
     @property
     def outline_thickness(self) -> float:
-        """text outline thickness"""
+        """get or set the outline thickness"""
         return self._outline_thickness.value
 
     @outline_thickness.setter
@@ -138,7 +138,7 @@ class TextGraphic(Graphic):
 
     @property
     def outline_color(self) -> pygfx.Color:
-        """text outline color"""
+        """get or set the outline color"""
         return self._outline_color.value
 
     @outline_color.setter

--- a/fastplotlib/layouts/_figure.py
+++ b/fastplotlib/layouts/_figure.py
@@ -157,7 +157,7 @@ class Figure:
             rects = [None] * n_subplots
 
         if names is not None:
-            # user has specified subplot names, check that there are enough subplots given the number of names
+            # user has specified subplot names
             subplot_names = np.asarray(names).flatten()
             # make an array without nones for sanity checks
             subplot_names_without_nones = subplot_names[subplot_names != np.array(None)]
@@ -171,20 +171,22 @@ class Figure:
                     f"subplot `names` must be unique, you have provided: {names}"
                 )
 
-            if subplot_names.size != n_subplots:
-                if subplot_names.size > n_subplots:
-                    # pad the subplot names with nones
-                    subplot_names = np.concatenate(
-                        [
-                            subplot_names,
-                            np.asarray([None] * (n_subplots - subplot_names.size)),
-                        ]
-                    )
-                else:
-                    raise ValueError(
-                        f"must provide same number of subplot `names` as specified by shape, extents, or rects."
-                        f"You have specified {n_subplots} subplots, but {subplot_names.size} subplot names."
-                    )
+            # check that there are enough subplots given the number of names
+            if subplot_names.size > n_subplots:
+                raise ValueError(
+                    f"must provide same number or fewer subplot `names` than number of supblots specified by shape, "
+                    f"extents, or rects."
+                    f"You have specified {n_subplots} subplots, but {subplot_names.size} subplot names."
+                )
+
+            if subplot_names.size < n_subplots:
+                # pad the subplot names with nones
+                subplot_names = np.concatenate(
+                    [
+                        subplot_names,
+                        np.asarray([None] * (n_subplots - subplot_names.size)),
+                    ]
+                )
         else:
             # no user specified subplot names
             if layout_mode == "grid":

--- a/fastplotlib/layouts/_figure.py
+++ b/fastplotlib/layouts/_figure.py
@@ -155,14 +155,30 @@ class Figure:
             rects = [None] * n_subplots
 
         if names is not None:
+            # user has specified subplot names, check that there are enough subplots given the number of names
             subplot_names = np.asarray(names).flatten()
-            if subplot_names.size != n_subplots:
+            # make an array without nones for sanity checks
+            subplot_names_without_nones = subplot_names[subplot_names != np.array(None)]
+
+            # make sure all names are unique
+            if subplot_names_without_nones.size != np.unique(subplot_names_without_nones).size:
                 raise ValueError(
-                    f"must provide same number of subplot `names` as specified by shape, extents, or rects."
-                    f"You have specified {n_subplots} subplots, but {subplot_names.size} subplot names."
+                    f"subplot `names` must be unique, you have provided: {names}"
                 )
+
+            if subplot_names.size != n_subplots:
+                if subplot_names.size > n_subplots:
+                    # pad the subplot names with nones
+                    subplot_names = np.concatenate([subplot_names, np.asarray([None] * (n_subplots - subplot_names.size))])
+                else:
+                    raise ValueError(
+                        f"must provide same number of subplot `names` as specified by shape, extents, or rects."
+                        f"You have specified {n_subplots} subplots, but {subplot_names.size} subplot names."
+                    )
         else:
+            # no user specified subplot names
             if layout_mode == "grid":
+                # make names that show the [row index, col index]
                 subplot_names = np.asarray(
                     list(map(str, product(range(shape[0]), range(shape[1]))))
                 )

--- a/fastplotlib/layouts/_figure.py
+++ b/fastplotlib/layouts/_figure.py
@@ -145,7 +145,9 @@ class Figure:
 
         else:
             if not all(isinstance(v, (int, np.integer)) for v in shape):
-                raise TypeError(f"shape argument must be a tuple[n_rows, n_cols], you have passed: {shape}")
+                raise TypeError(
+                    f"shape argument must be a tuple[n_rows, n_cols], you have passed: {shape}"
+                )
             n_subplots = shape[0] * shape[1]
             layout_mode = "grid"
 
@@ -161,7 +163,10 @@ class Figure:
             subplot_names_without_nones = subplot_names[subplot_names != np.array(None)]
 
             # make sure all names are unique
-            if subplot_names_without_nones.size != np.unique(subplot_names_without_nones).size:
+            if (
+                subplot_names_without_nones.size
+                != np.unique(subplot_names_without_nones).size
+            ):
                 raise ValueError(
                     f"subplot `names` must be unique, you have provided: {names}"
                 )
@@ -169,7 +174,12 @@ class Figure:
             if subplot_names.size != n_subplots:
                 if subplot_names.size > n_subplots:
                     # pad the subplot names with nones
-                    subplot_names = np.concatenate([subplot_names, np.asarray([None] * (n_subplots - subplot_names.size))])
+                    subplot_names = np.concatenate(
+                        [
+                            subplot_names,
+                            np.asarray([None] * (n_subplots - subplot_names.size)),
+                        ]
+                    )
                 else:
                     raise ValueError(
                         f"must provide same number of subplot `names` as specified by shape, extents, or rects."
@@ -452,7 +462,7 @@ class Figure:
 
     @property
     def shape(self) -> list[tuple[int, int, int, int]] | tuple[int, int]:
-        """Only for grid layouts of subplots: [n_rows, n_cols] """
+        """Only for grid layouts of subplots: [n_rows, n_cols]"""
         if isinstance(self.layout, GridLayout):
             return self.layout.shape
 

--- a/fastplotlib/layouts/_graphic_methods_mixin.py
+++ b/fastplotlib/layouts/_graphic_methods_mixin.py
@@ -51,7 +51,8 @@ class GraphicMethodsMixin:
             maximum value for color scaling, calculated from data if not provided
 
         cmap: str, optional, default "plasma"
-            colormap to use to display the data
+            colormap to use to display the data. For supported colormaps see the
+            ``cmap`` library catalogue: https://cmap-docs.readthedocs.io/en/stable/catalog/
 
         interpolation: str, optional, default "nearest"
             interpolation filter, one of "nearest" or "linear"
@@ -62,7 +63,8 @@ class GraphicMethodsMixin:
         isolated_buffer: bool, default True
             If True, initialize a buffer with the same shape as the input data and then
             set the data, useful if the data arrays are ready-only such as memmaps.
-            If False, the input array is itself used as the buffer.
+            If False, the input array is itself used as the buffer - useful if the
+            array is large.
 
         kwargs:
             additional keyword arguments passed to Graphic
@@ -176,11 +178,11 @@ class GraphicMethodsMixin:
         self,
         data: Any,
         thickness: float = 2.0,
-        colors: Union[str, numpy.ndarray, Iterable] = "w",
+        colors: Union[str, numpy.ndarray, Sequence] = "w",
         uniform_color: bool = False,
         alpha: float = 1.0,
         cmap: str = None,
-        cmap_transform: Union[numpy.ndarray, Iterable] = None,
+        cmap_transform: Union[numpy.ndarray, Sequence] = None,
         isolated_buffer: bool = True,
         size_space: str = "screen",
         **kwargs,
@@ -192,14 +194,17 @@ class GraphicMethodsMixin:
         Parameters
         ----------
         data: array-like
-            Line data to plot, 2D must be of shape [n_points, 2], 3D must be of shape [n_points, 3]
+            Line data to plot. Can provide 1D, 2D, or a 3D data.
+            | If passing a 1D array, it is used to set the y-values and the x-values are generated as an integer range
+            from [0, data.size]
+            | 2D data must be of shape [n_points, 2]. 3D data must be of shape [n_points, 3]
 
         thickness: float, optional, default 2.0
             thickness of the line
 
         colors: str, array, or iterable, default "w"
             specify colors as a single human-readable string, a single RGBA array,
-            or an iterable of strings or RGBA arrays
+            or a Sequence (array, tuple, or list) of strings or RGBA arrays
 
         uniform_color: bool, default ``False``
             if True, uses a uniform buffer for the line color,
@@ -209,14 +214,15 @@ class GraphicMethodsMixin:
             alpha value for the colors
 
         cmap: str, optional
-            apply a colormap to the line instead of assigning colors manually, this
-            overrides any argument passed to "colors"
+            Apply a colormap to the line instead of assigning colors manually, this
+            overrides any argument passed to "colors". For supported colormaps see the
+            ``cmap`` library catalogue: https://cmap-docs.readthedocs.io/en/stable/catalog/
 
         cmap_transform: 1D array-like of numerical values, optional
             if provided, these values are used to map the colors from the cmap
 
         size_space: str, default "screen"
-            coordinate space in which the size is expressed ("screen", "world", "model")
+            coordinate space in which the thickness is expressed ("screen", "world", "model")
 
         **kwargs
             passed to Graphic
@@ -346,7 +352,7 @@ class GraphicMethodsMixin:
         cmap: str = None,
         cmap_transform: numpy.ndarray = None,
         isolated_buffer: bool = True,
-        sizes: Union[float, numpy.ndarray, Iterable[float]] = 1,
+        sizes: Union[float, numpy.ndarray, Sequence[float]] = 1,
         uniform_size: bool = False,
         size_space: str = "screen",
         **kwargs,
@@ -358,36 +364,38 @@ class GraphicMethodsMixin:
         Parameters
         ----------
         data: array-like
-            Scatter data to plot, 2D must be of shape [n_points, 2], 3D must be of shape [n_points, 3]
+            Scatter data to plot, Can provide 2D, or a 3D data. 2D data must be of shape [n_points, 2].
+            3D data must be of shape [n_points, 3]
 
-        colors: str, array, or iterable, default "w"
-            specify colors as a single human readable string, a single RGBA array,
-            or an iterable of strings or RGBA arrays
+        colors: str, array, tuple, list, Sequence, default "w"
+            specify colors as a single human-readable string, a single RGBA array,
+            or a Sequence (array, tuple, or list) of strings or RGBA arrays
 
         uniform_color: bool, default False
-            if True, uses a uniform buffer for the scatter point colors,
-            basically saves GPU VRAM when the entire line has a single color
+            if True, uses a uniform buffer for the scatter point colors. Useful if you need to
+            save GPU VRAM when all points have the same color.
 
         alpha: float, optional, default 1.0
             alpha value for the colors
 
         cmap: str, optional
             apply a colormap to the scatter instead of assigning colors manually, this
-            overrides any argument passed to "colors"
+            overrides any argument passed to "colors".  For supported colormaps see the
+            ``cmap`` library catalogue: https://cmap-docs.readthedocs.io/en/stable/catalog/
 
         cmap_transform: 1D array-like or list of numerical values, optional
             if provided, these values are used to map the colors from the cmap
 
         isolated_buffer: bool, default True
             whether the buffers should be isolated from the user input array.
-            Generally always ``True``, ``False`` is for rare advanced use.
+            Generally always ``True``, ``False`` is for rare advanced use if you have large arrays.
 
         sizes: float or iterable of float, optional, default 1.0
-            size of the scatter points
+            sizes of the scatter points
 
         uniform_size: bool, default False
-            if True, uses a uniform buffer for the scatter point sizes,
-            basically saves GPU VRAM when all scatter points are the same size
+            if True, uses a uniform buffer for the scatter point sizes. Useful if you need to
+            save GPU VRAM when all points have the same size.
 
         size_space: str, default "screen"
             coordinate space in which the size is expressed ("screen", "world", "model")
@@ -436,10 +444,10 @@ class GraphicMethodsMixin:
         font_size: float | int, default 10
             font size
 
-        face_color: str or array, default "w"
+        face_color: str, array, list, tuple, default "w"
             str or RGBA array to set the color of the text
 
-        outline_color: str or array, default "w"
+        outline_color: str, array, list, tuple, default "w"
             str or RGBA array to set the outline color of the text
 
         outline_thickness: float, default 0

--- a/fastplotlib/utils/functions.py
+++ b/fastplotlib/utils/functions.py
@@ -269,8 +269,7 @@ def make_colors_dict(labels: Sequence, cmap: str, **kwargs) -> OrderedDict:
 
 def quick_min_max(data: np.ndarray, max_size=1e6) -> tuple[float, float]:
     """
-    Adapted from pyqtgraph.ImageView.
-    Estimate the min/max values of *data* by subsampling.
+    Estimate the min/max values of *data* by subsampling relative to the size of each dimension in the array.
 
     Parameters
     ----------

--- a/fastplotlib/widgets/image_widget/_widget.py
+++ b/fastplotlib/widgets/image_widget/_widget.py
@@ -329,7 +329,7 @@ class ImageWidget:
             manually provide the shape for the Figure, otherwise the number of rows and columns is estimated
 
         figure_kwargs: dict, optional
-            passed to `GridPlot`
+            passed to ``Figure``
 
         names: Optional[str]
             gives names to the subplots

--- a/scripts/generate_add_graphic_methods.py
+++ b/scripts/generate_add_graphic_methods.py
@@ -49,23 +49,26 @@ def generate_add_graphics_methods():
     f.write("        return graphic\n\n")
 
     for m in modules:
-        class_name = m
-        method_name = class_name.type
+        cls = m
+        if cls.__name__ == "Graphic":
+            # skip base class
+            continue
+        method_name = cls.type
 
-        class_args = inspect.getfullargspec(class_name)[0][1:]
+        class_args = inspect.getfullargspec(cls)[0][1:]
         class_args = [arg + ", " for arg in class_args]
         s = ""
         for a in class_args:
             s += a
 
         f.write(
-            f"    def add_{method_name}{inspect.signature(class_name.__init__)} -> {class_name.__name__}:\n"
+            f"    def add_{method_name}{inspect.signature(cls.__init__)} -> {cls.__name__}:\n"
         )
         f.write('        """\n')
-        f.write(f"        {class_name.__init__.__doc__}\n")
+        f.write(f"        {cls.__init__.__doc__}\n")
         f.write('        """\n')
         f.write(
-            f"        return self._create_graphic({class_name.__name__}, {s} **kwargs)\n\n"
+            f"        return self._create_graphic({cls.__name__}, {s} **kwargs)\n\n"
         )
 
     f.close()

--- a/tests/test_figure.py
+++ b/tests/test_figure.py
@@ -170,3 +170,93 @@ def test_set_controllers_from_existing_controllers():
     assert fig[0, 0].camera is cameras[0][0]
 
     assert fig[0, 1].camera.fov == 50
+
+
+def test_subplot_names():
+    # names must be unique
+    with pytest.raises(ValueError):
+        fpl.Figure(
+            shape=(2, 3),
+            names=["1", "2", "3", "4", "4", "5"]
+        )
+
+    with pytest.raises(ValueError):
+        fpl.Figure(
+            shape=(2, 3),
+            names=["1", "2", None, "4", "4", "5"]
+        )
+
+    with pytest.raises(ValueError):
+        fpl.Figure(
+            shape=(2, 3),
+            names=[None, "2", None, "4", "4", "5"]
+        )
+
+    # len(names) <= n_subplots
+    fig = fpl.Figure(
+        shape=(2, 3),
+        names=["1", "2", "3", "4", "5", "6"]
+    )
+
+    assert fig[0, 0].name == "1"
+    assert fig[0, 1].name == "2"
+    assert fig[0, 2].name == "3"
+    assert fig[1, 0].name == "4"
+    assert fig[1, 1].name == "5"
+    assert fig[1, 2].name == "6"
+
+    fig = fpl.Figure(
+        shape=(2, 3),
+        names=["1", "2", "3", None, "5", "6"]
+    )
+
+    assert fig[0, 0].name == "1"
+    assert fig[0, 1].name == "2"
+    assert fig[0, 2].name == "3"
+    assert fig[1, 0].name is None
+    assert fig[1, 1].name == "5"
+    assert fig[1, 2].name == "6"
+
+    fig = fpl.Figure(
+        shape=(2, 3),
+        names=["1", "2", "3", None, "5", None]
+    )
+
+    assert fig[0, 0].name == "1"
+    assert fig[0, 1].name == "2"
+    assert fig[0, 2].name == "3"
+    assert fig[1, 0].name is None
+    assert fig[1, 1].name == "5"
+    assert fig[1, 2].name is None
+
+    # if fewer subplot names are given than n_sublots, pad with Nones
+    fig = fpl.Figure(
+        shape=(2, 3),
+        names=["1", "2", "3", "4"]
+    )
+
+    assert fig[0, 0].name == "1"
+    assert fig[0, 1].name == "2"
+    assert fig[0, 2].name == "3"
+    assert fig[1, 0].name == "4"
+    assert fig[1, 1].name is None
+    assert fig[1, 2].name is None
+
+    # raise if len(names) > n_subplots
+    with pytest.raises(ValueError):
+        fpl.Figure(
+            shape=(2, 3),
+            names=["1", "2", "3", "4", "5", "6", "7"]
+        )
+
+    with pytest.raises(ValueError):
+        fpl.Figure(
+            shape=(2, 3),
+            names=["1", "2", "3", "4", None, "6", "7"]
+        )
+
+    with pytest.raises(ValueError):
+        fpl.Figure(
+            shape=(2, 3),
+            names=["1", None, "3", "4", None, "6", "7"]
+        )


### PR DESCRIPTION
Renamed lots of instances where gridplot was still lingering to Figure. There is no such thing as "grid plot" anymore so changed those descriptions to "grid layout".

Some other docstring cleanup, reword some things to be better. Some better error messages in `Figure.__init__()`

removed "padding" kwarg for `add_linear_selector()` methods since it's no longer required since we have inf lines :smile: 

also fixes #818 

@clewis7 ready for review
