### PR TITLE
retry sklearn datset downloads if 403 error

### DIFF
--- a/examples/events/scatter_hover_transforms.py
+++ b/examples/events/scatter_hover_transforms.py
@@ -24,7 +24,7 @@ import fastplotlib as fpl
 import pygfx
 
 # get the dataset
-dataset = fetch_california_housing()
+dataset = fetch_california_housing(n_retries=5, delay=20)
 X_full, y = dataset.data, dataset.target
 feature_names = dataset.feature_names
 

--- a/examples/machine_learning/covariance.py
+++ b/examples/machine_learning/covariance.py
@@ -14,7 +14,7 @@ from sklearn import datasets
 from sklearn.preprocessing import StandardScaler
 
 # load faces dataset
-faces = datasets.fetch_olivetti_faces()
+faces = datasets.fetch_olivetti_faces(n_retries=5, delay=20)
 data = faces["data"]
 
 # sort the data so it's easier to understand the covariance matrix


### PR DESCRIPTION
should fix the http 403 erros on CI, saves us from having to manually restart those jobs
