### PR TITLE
Check for histogram_lut vmin/vmax eager callbacks

### DIFF
--- a/fastplotlib/tools/_histogram_lut.py
+++ b/fastplotlib/tools/_histogram_lut.py
@@ -175,7 +175,7 @@ class HistogramLUTTool(Graphic):
     def _get_vmin_vmax_str(self) -> tuple[str, str]:
 
         # https://docs.dask.org/en/latest/generated/dask.array.Array.compute.html
-        lazy_callbacks = ("compute")
+        lazy_callbacks = ["compute"]
 
         def as_float(x) -> float:
             for name in lazy_callbacks:
@@ -192,8 +192,6 @@ class HistogramLUTTool(Graphic):
         vmax_str = f"{vmax:.2e}" if vmax < 1e-3 or vmax > 9.9999e4 else f"{vmax:.2f}"
 
         return vmin_str, vmax_str
-
-
 
     def _fpl_add_plot_area_hook(self, plot_area):
         self._plot_area = plot_area


### PR DESCRIPTION
Enables histograms with Dask arrays by checking for and calling [compute()](https://docs.dask.org/en/latest/generated/dask.array.Array.compute.html). 

Could add other lazy loading functions in the future to check for too. 

I was testing [item from tensors](https://docs.pytorch.org/docs/stable/generated/torch.Tensor.item.html) but I dont have a use case for it. Should probably wait until someone complains before adding more so removed it. The function definition might be overkill.


```python
# https://docs.dask.org/en/latest/generated/dask.array.Array.compute.html
# https://docs.pytorch.org/docs/stable/generated/torch.Tensor.item.html
lazy_callbacks = ("compute", "item")

def as_float(x) -> float:
    for name in lazy_callbacks:
        meth = getattr(x, name, None)
        if callable(meth):
            x = meth()
            break
    return float(x)

vmin = as_float(self.vmin)
vmax = as_float(self.vmax)

vmin_str = f"{vmin:.2e}" if vmin < 1e-3 or vmin > 9.9999e4 else f"{vmin:.2f}"
vmax_str = f"{vmax:.2e}" if vmax < 1e-3 or vmax > 9.9999e4 else f"{vmax:.2f}"
```