### PR TITLE
fix move to pointer for liner and linear region selctor

### DIFF
--- a/fastplotlib/graphics/selectors/_base_selector.py
+++ b/fastplotlib/graphics/selectors/_base_selector.py
@@ -323,7 +323,7 @@ class BaseSelector(Graphic):
         # if it was disabled, keep it disabled
         self._plot_area.controller.enabled = self._initial_controller_state
 
-    def _move_graphic(self, delta: np.ndarray):
+    def _move_graphic(self, move_info: MoveInfo):
         raise NotImplementedError("Must be implemented in subclass")
 
     def _move_end(self, ev):
@@ -381,11 +381,13 @@ class BaseSelector(Graphic):
                 delta=delta,
                 source=self._fill[0],
             )
+            print(move_info)
         # else use an edge, such as for linear selector
         else:
             move_info = MoveInfo(
-                start_position=current_pos_world,
-                last_position=current_pos_world,
+                start_position=None,
+                start_selection=None,
+                delta=delta,
                 source=self._edges[0],
             )
 

--- a/fastplotlib/graphics/selectors/_linear_region.py
+++ b/fastplotlib/graphics/selectors/_linear_region.py
@@ -381,7 +381,7 @@ class LinearRegionSelector(BaseSelector):
         cur_min, cur_max = move_info.start_selection
 
         # move entire selector if event source was fill
-        if self._move_info.source == self.fill:
+        if move_info.source == self.fill:
             # Limit the delta to avoid weird resizine behavior
             min_delta = self.limits[0] - cur_min
             max_delta = self.limits[1] - cur_max
@@ -396,12 +396,12 @@ class LinearRegionSelector(BaseSelector):
 
         # if event source was an edge and selector is resizable,
         # move the edge that caused the event
-        if self._move_info.source == self.edges[0]:
+        if move_info.source == self.edges[0]:
             # change only left or bottom bound
             new_min = min(cur_min + delta, cur_max)
             self._selection.set_value(self, (new_min, cur_max))
 
-        elif self._move_info.source == self.edges[1]:
+        elif move_info.source == self.edges[1]:
             # change only right or top bound
             new_max = max(cur_max + delta, cur_min)
             self._selection.set_value(self, (cur_min, new_max))

--- a/fastplotlib/graphics/selectors/_rectangle.py
+++ b/fastplotlib/graphics/selectors/_rectangle.py
@@ -491,7 +491,7 @@ class RectangleSelector(BaseSelector):
         xmin, xmax, ymin, ymax = move_info.start_selection
 
         # move entire selector if source is fill
-        if self._move_info.source == self.fill:
+        if move_info.source == self.fill:
             # Limit the delta to avoid weird resizine behavior
             min_deltax = self.limits[0] - xmin
             max_deltax = self.limits[1] - xmax
@@ -514,22 +514,22 @@ class RectangleSelector(BaseSelector):
         ymin_new = min(ymin + deltay, ymax)
         ymax_new = max(ymax + deltay, ymin)
 
-        if self._move_info.source == self.vertices[0]:  # bottom left
+        if move_info.source == self.vertices[0]:  # bottom left
             self._selection.set_value(self, (xmin_new, xmax, ymin_new, ymax))
-        if self._move_info.source == self.vertices[1]:  # bottom right
+        if move_info.source == self.vertices[1]:  # bottom right
             self._selection.set_value(self, (xmin, xmax_new, ymin_new, ymax))
-        if self._move_info.source == self.vertices[2]:  # top left
+        if move_info.source == self.vertices[2]:  # top left
             self._selection.set_value(self, (xmin_new, xmax, ymin, ymax_new))
-        if self._move_info.source == self.vertices[3]:  # top right
+        if move_info.source == self.vertices[3]:  # top right
             self._selection.set_value(self, (xmin, xmax_new, ymin, ymax_new))
         # if event source was an edge and selector is resizable, move the edge that caused the event
-        if self._move_info.source == self.edges[0]:
+        if move_info.source == self.edges[0]:
             self._selection.set_value(self, (xmin_new, xmax, ymin, ymax))
-        if self._move_info.source == self.edges[1]:
+        if move_info.source == self.edges[1]:
             self._selection.set_value(self, (xmin, xmax_new, ymin, ymax))
-        if self._move_info.source == self.edges[2]:
+        if move_info.source == self.edges[2]:
             self._selection.set_value(self, (xmin, xmax, ymin_new, ymax))
-        if self._move_info.source == self.edges[3]:
+        if move_info.source == self.edges[3]:
             self._selection.set_value(self, (xmin, xmax, ymin, ymax_new))
 
     def _move_to_pointer(self, ev):


### PR DESCRIPTION
fixes the `move_to_pointer` upon middle mouse click for linear and linear region selectors.

also uses the passed `move_info` for the `move_graphic` methods, @almarklein does this look good to you?

closes #854 
