### PR TITLE
fix image_widget_grid git LFS pointer

### DIFF
--- a/examples/screenshots/image_widget_grid.png
+++ b/examples/screenshots/image_widget_grid.png
@@ -1,4 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-
 oid sha256:430cd0ee5c05221c42073345480acbeee672c299311f239dc0790a9495d0d758
 size 248046


### PR DESCRIPTION
`git lfs` is leading to  errors in that install fastplotlib from github with `git+` syntax. 

This PR should fix that by re-adding a properly formatted `lfs` pointer for the corrupted `image_widget_grid.png`. 

Closes #861 

## Sources 
- https://stackoverflow.com/questions/46521122/smudge-error-error-downloading
- https://github.com/git-lfs/git-lfs/issues/1720#issuecomment-263290861