### PR TITLE
Imgui pin to attempt bugfix release

### DIFF
--- a/fastplotlib/_version.py
+++ b/fastplotlib/_version.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 # This is the reference version number, to be bumped before each release.
 # The build system detects this definition when building a distribution.
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 # Allow using nearly the same code in different projects
 project_name = "fastplotlib"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords = [
 requires-python = ">= 3.10"
 dependencies = [
     "numpy>=1.23.0",
-    "pygfx==0.10.0",
+    "pygfx==0.12.0",
     "wgpu>=0.20.0",
     "cmap>=0.1.3",
     # (this comment keeps this list multiline in VSCode)
@@ -55,7 +55,7 @@ tests = [
     "scikit-learn",
     "tqdm",
 ]
-imgui = ["imgui-bundle"]
+imgui = ["imgui-bundle>=1.6.0,<1.92.0"]
 dev = ["fastplotlib[docs,notebook,tests,imgui]"]
 
 [project.urls]


### PR DESCRIPTION
I think https://github.com/pygfx/wgpu-py/issues/723 will take a while to resolve and then wait for a wgpu release before we can release fpl v0.6.0. Also once we merge #838 into main then we have to wait for the next release of pygfx before we can release fpl v0.6.0. So let's see if we can do a bugfix release for v0.5 right now to prevent users running into imgui font errors
