### PR TITLE
remove graphic suffix

### DIFF
--- a/examples/events/drag_points.py
+++ b/examples/events/drag_points.py
@@ -23,16 +23,16 @@ data = np.column_stack([xs, ys])
 figure = fpl.Figure(size=(700, 560))
 
 # add a line
-line_graphic = figure[0, 0].add_line(data)
+line = figure[0, 0].add_line(data)
 
 # add a scatter, share the line graphic buffer!
-scatter_graphic = figure[0, 0].add_scatter(data=line_graphic.data, sizes=25, colors="r")
+scatter = figure[0, 0].add_scatter(data=line.data, sizes=25, colors="r")
 
 is_moving = False
 vertex_index = None
 
 
-@scatter_graphic.add_event_handler("pointer_down")
+@scatter.add_event_handler("pointer_down")
 def start_drag(ev: pygfx.PointerEvent):
     global is_moving
     global vertex_index
@@ -42,7 +42,7 @@ def start_drag(ev: pygfx.PointerEvent):
 
     is_moving = True
     vertex_index = ev.pick_info["vertex_index"]
-    scatter_graphic.colors[vertex_index] = "cyan"
+    scatter.colors[vertex_index] = "cyan"
 
 
 @figure.renderer.add_event_handler("pointer_move")
@@ -63,13 +63,13 @@ def move_point(ev):
     if pos is None:
         # end movement
         is_moving = False
-        scatter_graphic.colors[vertex_index] = "r"  # reset color
+        scatter.colors[vertex_index] = "r"  # reset color
         vertex_index = None
         return
 
     # change scatter data
     # since we are sharing the buffer, the line data will also change
-    scatter_graphic.data[vertex_index, :-1] = pos[:-1]
+    scatter.data[vertex_index, :-1] = pos[:-1]
 
     # re-enable controller
     figure[0, 0].controller.enabled = True
@@ -83,7 +83,7 @@ def end_drag(ev: pygfx.PointerEvent):
     # end movement
     if is_moving:
         # reset color
-        scatter_graphic.colors[vertex_index] = "r"
+        scatter.colors[vertex_index] = "r"
 
     is_moving = False
     vertex_index = None

--- a/examples/events/image_click.py
+++ b/examples/events/image_click.py
@@ -18,14 +18,14 @@ data = iio.imread("imageio:camera.png")
 figure = fpl.Figure(size=(700, 560))
 
 # create image graphic
-image_graphic = figure[0, 0].add_image(data=data)
+image = figure[0, 0].add_image(data=data)
 
 # show the plot
 figure.show()
 
 
 # adding a click event, we can also use decorators to add event handlers
-@image_graphic.add_event_handler("click")
+@image.add_event_handler("click")
 def click_event(ev: pygfx.PointerEvent):
     # get the click location in screen coordinates
     xy = (ev.x, ev.y)

--- a/examples/events/line_data_thickness_event.py
+++ b/examples/events/line_data_thickness_event.py
@@ -23,11 +23,11 @@ ys = np.cos(xs)
 cosine = np.column_stack([xs, ys])
 
 # create line graphics
-sine_graphic = figure[0, 0].add_line(data=sine)
-cosine_graphic = figure[0, 0].add_line(data=cosine, offset=(0, 4, 0))
+sine = figure[0, 0].add_line(data=sine)
+cosine = figure[0, 0].add_line(data=cosine, offset=(0, 4, 0))
 
 # make a list of the line graphics for convenience
-lines = [sine_graphic, cosine_graphic]
+lines = [sine, cosine]
 
 
 def change_thickness(ev: fpl.GraphicFeatureEvent):
@@ -66,11 +66,11 @@ figure[0, 0].axes.intersection = (0, 0, 0)
 # set the y-value of the middle 40 points of the sine graphic to 1
 # after the sine_graphic sets its data, the event handlers will be called
 # and therefore the cosine graphic will also set its data using the event data
-sine_graphic.data[30:70, 1] = np.ones(40)
+sine.data[30:70, 1] = np.ones(40)
 
 # set the thickness of the cosine graphic, this will trigger an event
 # that causes the sine graphic's thickness to also be set from this value
-cosine_graphic.thickness = 10
+cosine.thickness = 10
 
 # NOTE: fpl.loop.run() should not be used for interactive sessions
 # See the "JupyterLab and IPython" section in the user guide

--- a/examples/guis/sine_cosine_funcs.py
+++ b/examples/guis/sine_cosine_funcs.py
@@ -61,55 +61,55 @@ figure["cos"].camera.maintain_aspect = False
 
 # create sine and cosine data
 xs = np.linspace(0, 2 * np.pi, 360)
-sine = np.sin(xs * P)
-cosine = np.cos(xs * Q)
+sine_data = np.sin(xs * P)
+cosine_data = np.cos(xs * Q)
 
 # circle data
 circle_data = make_circle(center=(0, 0), p=P, q=Q, radius=1, n_points=360)
 
 # make the circle line graphic, set the cmap transform using the sine function
-circle_graphic = figure["circle"].add_line(
-    circle_data, thickness=4, cmap="bwr", cmap_transform=sine
+circle = figure["circle"].add_line(
+    circle_data, thickness=4, cmap="bwr", cmap_transform=sine_data
 )
 
 # line to show the circle radius
 # use it to indicate the current position of the sine and cosine selctors (below)
 radius_data = np.array([[0, 0, 0], [*circle_data[0], 0]])
-circle_radius_graphic = figure["circle"].add_line(
+circle_radius = figure["circle"].add_line(
     radius_data, thickness=6, colors="magenta"
 )
 
 # sine line graphic, cmap transform set from the sine function
-sine_graphic = figure["sin"].add_line(
-    sine, thickness=10, cmap="bwr", cmap_transform=sine
+sine = figure["sin"].add_line(
+    sine_data, thickness=10, cmap="bwr", cmap_transform=sine_data
 )
 
 # cosine line graphic, cmap transform set from the sine function
 # illustrates the sine function values on the cosine graphic
-cosine_graphic = figure["cos"].add_line(
-    cosine, thickness=10, cmap="bwr", cmap_transform=sine
+cosine = figure["cos"].add_line(
+    cosine_data, thickness=10, cmap="bwr", cmap_transform=sine_data
 )
 
 # add linear selectors to the sine and cosine line graphics
-sine_selector = sine_graphic.add_linear_selector()
-cosine_selector = cosine_graphic.add_linear_selector()
+sine_selector = sine.add_linear_selector()
+cosine_selector = cosine.add_linear_selector()
 
 
 def set_circle_cmap(ev):
     # sets the cmap transforms
 
     cmap_transform = ev.graphic.data[:, 1]  # y-val data of the sine or cosine graphic
-    for g in [sine_graphic, cosine_graphic]:
+    for g in [sine, cosine]:
         g.cmap.transform = cmap_transform
 
     # set circle cmap transform
-    circle_graphic.cmap.transform = cmap_transform
+    circle.cmap.transform = cmap_transform
 
 # when the sine or cosine graphic is clicked, the cmap_transform
 # of the sine, cosine and circle line graphics are all set from
 # the y-values of the clicked line
-sine_graphic.add_event_handler(set_circle_cmap, "click")
-cosine_graphic.add_event_handler(set_circle_cmap, "click")
+sine.add_event_handler(set_circle_cmap, "click")
+cosine.add_event_handler(set_circle_cmap, "click")
 
 
 def set_x_val(ev):
@@ -120,7 +120,7 @@ def set_x_val(ev):
     sine_selector.selection = value
     cosine_selector.selection = value
 
-    circle_radius_graphic.data[1, :-1] = circle_data[index]
+    circle_radius.data[1, :-1] = circle_data[index]
 
 # add same event handler to both graphics
 sine_selector.add_event_handler(set_x_val, "selection")
@@ -138,19 +138,19 @@ class GUIWindow(EdgeWindow):
         self._q = 1
 
     def _set_data(self):
-        global sine_graphic, cosine_graphic, circle_graphic, circle_radius_graphic, circle_data
+        global sine, cosine, circle, circle_radius, circle_data
 
         # make new data
-        sine = np.sin(xs * self._p)
-        cosine = np.cos(xs * self._q)
+        sine_data = np.sin(xs * self._p)
+        cosine_data = np.cos(xs * self._q)
         circle_data = make_circle(center=(0, 0), p=self._p, q=self._q, radius=1, n_points=360)
 
 
         # set the graphics
-        sine_graphic.data[:, 1] = sine
-        cosine_graphic.data[:, 1] = cosine
-        circle_graphic.data[:, :2] = circle_data
-        circle_radius_graphic.data[1, :-1] = circle_data[sine_selector.get_selected_index()]
+        sine.data[:, 1] = sine_data
+        cosine.data[:, 1] = cosine_data
+        circle.data[:, :2] = circle_data
+        circle_radius.data[1, :-1] = circle_data[sine_selector.get_selected_index()]
 
     def update(self):
         flag_set_data = False

--- a/examples/heatmap/heatmap.py
+++ b/examples/heatmap/heatmap.py
@@ -21,7 +21,7 @@ sine = np.sin(np.sqrt(xs))
 data = np.vstack([sine * i for i in range(2_300)])
 
 # plot the image data
-img = figure[0, 0].add_image(data=data, name="heatmap")
+image = figure[0, 0].add_image(data=data, name="heatmap")
 del data
 
 figure.show()

--- a/examples/image/image_cmap.py
+++ b/examples/image/image_cmap.py
@@ -8,19 +8,20 @@ Example showing simple plot creation and subsequent cmap change with Standard im
 # test_example = true
 # sphinx_gallery_pygfx_docs = 'screenshot'
 
-import fastplotlib as fpl
 import imageio.v3 as iio
+
+import fastplotlib as fpl
 
 im = iio.imread("imageio:camera.png")
 
 figure = fpl.Figure(size=(700, 560))
 
 # plot the image data
-image_graphic = figure[0, 0].add_image(data=im, name="random-image")
+image = figure[0, 0].add_image(data=im, name="random-image")
 
 figure.show()
 
-image_graphic.cmap = "viridis"
+image.cmap = "viridis"
 
 # NOTE: fpl.loop.run() should not be used for interactive sessions
 # See the "JupyterLab and IPython" section in the user guide

--- a/examples/image/image_rgb.py
+++ b/examples/image/image_rgb.py
@@ -16,7 +16,7 @@ im = iio.imread("imageio:astronaut.png")
 figure = fpl.Figure(size=(700, 560))
 
 # plot the image data
-image_graphic = figure[0, 0].add_image(data=im, name="iio astronaut")
+image = figure[0, 0].add_image(data=im, name="iio astronaut")
 
 figure.show()
 

--- a/examples/image/image_rgbvminvmax.py
+++ b/examples/image/image_rgbvminvmax.py
@@ -16,12 +16,12 @@ im = iio.imread("imageio:astronaut.png")
 figure = fpl.Figure(size=(700, 560))
 
 # plot the image data
-image_graphic = figure[0, 0].add_image(data=im, name="iio astronaut")
+image = figure[0, 0].add_image(data=im, name="iio astronaut")
 
 figure.show()
 
-image_graphic.vmin = 0.5
-image_graphic.vmax = 0.75
+image.vmin = 0.5
+image.vmax = 0.75
 
 # NOTE: fpl.loop.run() should not be used for interactive sessions
 # See the "JupyterLab and IPython" section in the user guide

--- a/examples/image/image_simple.py
+++ b/examples/image/image_simple.py
@@ -16,7 +16,7 @@ figure = fpl.Figure(size=(700, 560))
 data = iio.imread("imageio:camera.png")
 
 # plot the image data
-image_graphic = figure[0, 0].add_image(data=data, name="iio camera")
+image = figure[0, 0].add_image(data=data, name="iio camera")
 
 figure.show()
 

--- a/examples/image/image_small.py
+++ b/examples/image/image_small.py
@@ -18,7 +18,7 @@ data = np.array(
     [[0, 1, 2],
      [3, 4, 5]]
 )
-image_graphic = figure[0, 0].add_image(data)
+image = figure[0, 0].add_image(data)
 
 figure.show()
 

--- a/examples/image/image_vminvmax.py
+++ b/examples/image/image_vminvmax.py
@@ -16,12 +16,12 @@ figure = fpl.Figure(size=(700, 560))
 data = iio.imread("imageio:astronaut.png")
 
 # plot the image data
-image_graphic = figure[0, 0].add_image(data=data, name="iio astronaut")
+image = figure[0, 0].add_image(data=data, name="iio astronaut")
 
 figure.show()
 
-image_graphic.vmin = 0.5
-image_graphic.vmax = 0.75
+image.vmin = 0.5
+image.vmax = 0.75
 
 # NOTE: fpl.loop.run() should not be used for interactive sessions
 # See the "JupyterLab and IPython" section in the user guide

--- a/examples/line/line.py
+++ b/examples/line/line.py
@@ -16,25 +16,25 @@ figure = fpl.Figure(size=(700, 560))
 xs = np.linspace(-10, 10, 100)
 # sine wave
 ys = np.sin(xs)
-sine = np.dstack([xs, ys])[0]
+sine_data = np.dstack([xs, ys])[0]
 
 # cosine wave
 ys = np.cos(xs) + 5
-cosine = np.dstack([xs, ys])[0]
+cosine_data = np.dstack([xs, ys])[0]
 
 # sinc function
 a = 0.5
 ys = np.sinc(xs) * 3 + 8
-sinc = np.dstack([xs, ys])[0]
+sinc_data = np.dstack([xs, ys])[0]
 
-sine_graphic = figure[0, 0].add_line(data=sine, thickness=5, colors="magenta")
+sine = figure[0, 0].add_line(data=sine_data, thickness=5, colors="magenta")
 
 # you can also use colormaps for lines!
-cosine_graphic = figure[0, 0].add_line(data=cosine, thickness=12, cmap="autumn")
+cosine = figure[0, 0].add_line(data=cosine_data, thickness=12, cmap="autumn")
 
 # or a list of colors for each datapoint
 colors = ["r"] * 25 + ["purple"] * 25 + ["y"] * 25 + ["b"] * 25
-sinc_graphic = figure[0, 0].add_line(data=sinc, thickness=5, colors=colors)
+sinc = figure[0, 0].add_line(data=sinc_data, thickness=5, colors=colors)
 
 figure[0, 0].axes.grids.xy.visible = True
 figure.show()

--- a/examples/line/line_cmap.py
+++ b/examples/line/line_cmap.py
@@ -16,24 +16,24 @@ figure = fpl.Figure(size=(700, 560))
 xs = np.linspace(-10, 10, 100)
 # sine wave
 ys = np.sin(xs)
-sine = np.dstack([xs, ys])[0]
+sine_data = np.dstack([xs, ys])[0]
 
 # cosine wave
 ys = np.cos(xs) - 5
-cosine = np.dstack([xs, ys])[0]
+cosine_data = np.dstack([xs, ys])[0]
 
 # cmap_transform from an array, so the colors on the sine line will be based on the sine y-values
-sine_graphic = figure[0, 0].add_line(
-    data=sine,
+sine = figure[0, 0].add_line(
+    data=sine_data,
     thickness=10,
     cmap="plasma",
-    cmap_transform=sine[:, 1]
+    cmap_transform=sine_data[:, 1]
 )
 
 # qualitative colormaps, useful for cluster labels or other types of categorical labels
 labels = [0] * 25 + [5] * 10 + [1] * 35 + [2] * 30
-cosine_graphic = figure[0, 0].add_line(
-    data=cosine,
+cosine = figure[0, 0].add_line(
+    data=cosine_data,
     thickness=10,
     cmap="tab10",
     cmap_transform=labels

--- a/examples/line/line_colorslice.py
+++ b/examples/line/line_colorslice.py
@@ -16,26 +16,26 @@ figure = fpl.Figure(size=(700, 560))
 xs = np.linspace(-10, 10, 100)
 # sine wave
 ys = np.sin(xs)
-sine = np.column_stack([xs, ys])
+sine_data = np.column_stack([xs, ys])
 
 # cosine wave
 ys = np.cos(xs)
-cosine = np.column_stack([xs, ys])
+cosine_data = np.column_stack([xs, ys])
 
 # sinc function
 a = 0.5
 ys = np.sinc(xs) * 3
-sinc = np.column_stack([xs, ys])
+sinc_data = np.column_stack([xs, ys])
 
-sine_graphic = figure[0, 0].add_line(
-    data=sine,
+sine = figure[0, 0].add_line(
+    data=sine_data,
     thickness=5,
     colors="magenta"
 )
 
 # you can also use colormaps for lines!
-cosine_graphic = figure[0, 0].add_line(
-    data=cosine,
+cosine = figure[0, 0].add_line(
+    data=cosine_data,
     thickness=12,
     cmap="autumn",
     offset=(0, 3, 0)  # places the graphic at a y-axis offset of 3, offsets don't affect data
@@ -43,8 +43,8 @@ cosine_graphic = figure[0, 0].add_line(
 
 # or a list of colors for each datapoint
 colors = ["r"] * 25 + ["purple"] * 25 + ["y"] * 25 + ["b"] * 25
-sinc_graphic = figure[0, 0].add_line(
-    data=sinc,
+sinc = figure[0, 0].add_line(
+    data=sinc_data,
     thickness=5,
     colors=colors,
     offset=(0, 6, 0)
@@ -52,7 +52,7 @@ sinc_graphic = figure[0, 0].add_line(
 
 zeros = np.zeros(xs.size)
 zeros_data = np.column_stack([xs, zeros])
-zeros_graphic = figure[0, 0].add_line(
+zeros = figure[0, 0].add_line(
     data=zeros_data,
     thickness=8,
     colors="w",
@@ -62,25 +62,25 @@ zeros_graphic = figure[0, 0].add_line(
 figure.show()
 
 # indexing of colors
-cosine_graphic.colors[:15] = "magenta"
-cosine_graphic.colors[90:] = "red"
-cosine_graphic.colors[60] = "w"
+cosine.colors[:15] = "magenta"
+cosine.colors[90:] = "red"
+cosine.colors[60] = "w"
 
 # more complex indexing, set the blue value directly from an array
-cosine_graphic.colors[65:90, 0] = np.linspace(0, 1, 90-65)
+cosine.colors[65:90, 0] = np.linspace(0, 1, 90 - 65)
 
 # additional fancy indexing using numpy
 key = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 67, 19])
-sinc_graphic.colors[key] = "Red"
+sinc.colors[key] = "Red"
 
 # boolean fancy indexing
-zeros_graphic.colors[xs < -5] = "green"
+zeros.colors[xs < -5] = "green"
 
 # assign colormap to an entire line
-sine_graphic.cmap = "seismic"
+sine.cmap = "seismic"
 # or to segments of a line
-zeros_graphic.cmap[50:75] = "jet"
-zeros_graphic.cmap[75:] = "viridis"
+zeros.cmap[50:75] = "jet"
+zeros.cmap[75:] = "viridis"
 
 
 # NOTE: fpl.loop.run() should not be used for interactive sessions

--- a/examples/line/line_dataslice.py
+++ b/examples/line/line_dataslice.py
@@ -16,35 +16,35 @@ figure = fpl.Figure(size=(700, 560))
 xs = np.linspace(-10, 10, 100)
 # sine wave
 ys = np.sin(xs)
-sine = np.dstack([xs, ys])[0]
+sine_data = np.dstack([xs, ys])[0]
 
 # cosine wave
 ys = np.cos(xs) + 5
-cosine = np.dstack([xs, ys])[0]
+cosine_data = np.dstack([xs, ys])[0]
 
 # sinc function
 a = 0.5
 ys = np.sinc(xs) * 3 + 8
-sinc = np.dstack([xs, ys])[0]
+sinc_data = np.dstack([xs, ys])[0]
 
-sine_graphic = figure[0, 0].add_line(data=sine, thickness=5, colors="magenta")
+sine = figure[0, 0].add_line(data=sine_data, thickness=5, colors="magenta")
 
 # you can also use colormaps for lines!
-cosine_graphic = figure[0, 0].add_line(data=cosine, thickness=12, cmap="autumn")
+cosine = figure[0, 0].add_line(data=cosine_data, thickness=12, cmap="autumn")
 
 # or a list of colors for each datapoint
 colors = ["r"] * 25 + ["purple"] * 25 + ["y"] * 25 + ["b"] * 25
-sinc_graphic = figure[0, 0].add_line(data=sinc, thickness=5, colors=colors)
+sinc = figure[0, 0].add_line(data=sinc_data, thickness=5, colors=colors)
 
 figure.show()
 
-cosine_graphic.data[10:50:5, :2] = sine[10:50:5]
-cosine_graphic.data[90:, 1] = 7
-cosine_graphic.data[0] = np.array([[-10, 0, 0]])
+cosine.data[10:50:5, :2] = sine_data[10:50:5]
+cosine.data[90:, 1] = 7
+cosine.data[0] = np.array([[-10, 0, 0]])
 
 # additional fancy indexing with boolean array
 bool_key = [True, True, True, False, False] * 20
-sinc_graphic.data[bool_key, 1] = 7  # y vals to 1
+sinc.data[bool_key, 1] = 7  # y vals to 1
 
 
 # NOTE: fpl.loop.run() should not be used for interactive sessions

--- a/examples/misc/cycle_animation.py
+++ b/examples/misc/cycle_animation.py
@@ -37,16 +37,16 @@ colors = ["yellow"] * n_points + ["cyan"] * n_points + ["magenta"] * n_points
 figure = fpl.Figure(size=(700, 560))
 subplot_scatter = figure[0, 0]
 # use an alpha value since this will be a lot of points
-scatter_graphic = subplot_scatter.add_scatter(data=cloud, sizes=3, colors=colors, alpha=0.6)
+scatter = subplot_scatter.add_scatter(data=cloud, sizes=3, colors=colors, alpha=0.6)
 
 
 i = 0.05
 def cycle_colors(subplot):
     global i
     # cycle the red values
-    scatter_graphic.colors[n_points * 2:, 0] = np.abs(np.sin(i))
-    scatter_graphic.colors[n_points * 2:, 1] = np.abs(np.sin(i + (np.pi / 4)))
-    scatter_graphic.colors[n_points * 2:, 2] = np.abs(np.cos(i))
+    scatter.colors[n_points * 2:, 0] = np.abs(np.sin(i))
+    scatter.colors[n_points * 2:, 1] = np.abs(np.sin(i + (np.pi / 4)))
+    scatter.colors[n_points * 2:, 2] = np.abs(np.cos(i))
     i += 0.05
 
 subplot_scatter.add_animations(cycle_colors)

--- a/examples/misc/image_animation.py
+++ b/examples/misc/image_animation.py
@@ -16,10 +16,10 @@ data = np.random.rand(512, 512)
 figure = fpl.Figure(size=(700, 560))
 
 # plot the image data
-image_graphic = figure[0, 0].add_image(data=data, name="random-image")
+image = figure[0, 0].add_image(data=data, name="random-image")
 
 
-# a function to update the image_graphic
+# a function to update the image
 # a figure-level animation function will optionally take the figure as an argument
 def update_data(figure_instance):
     new_data = np.random.rand(512, 512)

--- a/examples/misc/line3d_animation.py
+++ b/examples/misc/line3d_animation.py
@@ -23,7 +23,7 @@ spiral = np.dstack([xs, ys, zs])[0]
 
 figure = fpl.Figure(cameras="3d", size=(700, 560))
 
-line_graphic = figure[0,0].add_line(data=spiral, thickness=3, cmap='jet')
+line = figure[0,0].add_line(data=spiral, thickness=3, cmap='jet')
 
 marker = figure[0,0].add_scatter(data=spiral[0], sizes=10, name="marker")
 

--- a/examples/misc/scatter_animation.py
+++ b/examples/misc/scatter_animation.py
@@ -37,13 +37,13 @@ colors = ["yellow"] * n_points + ["cyan"] * n_points + ["magenta"] * n_points
 figure = fpl.Figure(size=(700, 560))
 subplot_scatter = figure[0, 0]
 # use an alpha value since this will be a lot of points
-scatter_graphic = subplot_scatter.add_scatter(data=cloud, sizes=3, colors=colors, alpha=0.6)
+scatter = subplot_scatter.add_scatter(data=cloud, sizes=3, colors=colors, alpha=0.6)
 
 
 def update_points(subplot):
     # move every point by a small amount
-    deltas = np.random.normal(size=scatter_graphic.data.value.shape, loc=0, scale=0.15)
-    scatter_graphic.data = scatter_graphic.data.value + deltas
+    deltas = np.random.normal(size=scatter.data.value.shape, loc=0, scale=0.15)
+    scatter.data = scatter.data.value + deltas
 
 
 subplot_scatter.add_animations(update_points)

--- a/examples/misc/tooltips_custom.py
+++ b/examples/misc/tooltips_custom.py
@@ -23,7 +23,7 @@ data = dataset["data"]
 agg = AgglomerativeClustering(n_clusters=3)
 agg.fit_predict(data)
 
-scatter_graphic = figure[0, 0].add_scatter(
+scatter = figure[0, 0].add_scatter(
     data=data[:, :-1],  # use only xy data
     sizes=15,
     cmap="Set1",
@@ -44,7 +44,7 @@ def tooltip_info(ev) -> str:
     return info
 
 
-figure.tooltip_manager.register(scatter_graphic, custom_info=tooltip_info)
+figure.tooltip_manager.register(scatter, custom_info=tooltip_info)
 
 figure.show()
 

--- a/examples/notebooks/quickstart.ipynb
+++ b/examples/notebooks/quickstart.ipynb
@@ -720,10 +720,10 @@
     "subplot = fig_lines[0, 0]\n",
     "\n",
     "# plot sine wave, use a single color\n",
-    "sine_graphic = subplot.add_line(data=sine, thickness=5, colors=\"magenta\")\n",
+    "sine = subplot.add_line(data=sine, thickness=5, colors=\"magenta\")\n",
     "\n",
     "# you can also use colormaps for lines!\n",
-    "cosine_graphic = subplot.add_line(data=cosine, thickness=12, cmap=\"autumn\")\n",
+    "cosine = subplot.add_line(data=cosine, thickness=12, cmap=\"autumn\")\n",
     "\n",
     "# or a list of colors for each datapoint\n",
     "colors = [\"r\"] * 25 + [\"purple\"] * 25 + [\"y\"] * 25 + [\"b\"] * 25\n",
@@ -796,16 +796,16 @@
    "outputs": [],
    "source": [
     "# indexing of colors\n",
-    "cosine_graphic.colors[:15] = \"magenta\"\n",
-    "cosine_graphic.colors[90:] = \"red\"\n",
-    "cosine_graphic.colors[60] = \"w\"\n",
+    "cosine.colors[:15] = \"magenta\"\n",
+    "cosine.colors[90:] = \"red\"\n",
+    "cosine.colors[60] = \"w\"\n",
     "\n",
     "# indexing to assign colormaps to entire lines or segments\n",
     "sinc_graphic.cmap[10:50] = \"gray\"\n",
-    "sine_graphic.cmap = \"seismic\"\n",
+    "sine.cmap = \"seismic\"\n",
     "\n",
     "# more complex indexing, set the blue value directly from an array\n",
-    "cosine_graphic.colors[65:90, 0] = np.linspace(0, 1, 90-65)"
+    "cosine.colors[65:90, 0] = np.linspace(0, 1, 90 - 65)"
    ]
   },
   {
@@ -827,7 +827,7 @@
     "    print(event_data)\n",
     "\n",
     "# Will print event data when the color changes\n",
-    "cosine_graphic.add_event_handler(callback_func, \"colors\")"
+    "cosine.add_event_handler(callback_func, \"colors\")"
    ]
   },
   {
@@ -839,7 +839,7 @@
    "source": [
     "# more complex indexing of colors\n",
     "# from point 15 - 30, set every 3rd point as \"cyan\"\n",
-    "cosine_graphic.colors[15:50:3] = \"cyan\""
+    "cosine.colors[15:50:3] = \"cyan\""
    ]
   },
   {
@@ -870,8 +870,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cosine_graphic.data[10:50:5, :2] = sine[10:50:5]\n",
-    "cosine_graphic.data[90:, 1] = 7"
+    "cosine.data[10:50:5, :2] = sine[10:50:5]\n",
+    "cosine.data[90:, 1] = 7"
    ]
   },
   {
@@ -880,9 +880,7 @@
    "id": "682db47b-8c7a-4934-9be4-2067e9fb12d5",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "cosine_graphic.data[0] = np.array([[-10, 0, 0]])"
-   ]
+   "source": "cosine.data[0] = np.array([[-10, 0, 0]])"
   },
   {
    "cell_type": "code",

--- a/examples/scatter/scatter_cmap_iris.py
+++ b/examples/scatter/scatter_cmap_iris.py
@@ -20,7 +20,7 @@ data = datasets.load_iris()["data"]
 agg = AgglomerativeClustering(n_clusters=3)
 agg.fit_predict(data)
 
-scatter_graphic = figure[0, 0].add_scatter(
+scatter = figure[0, 0].add_scatter(
     data=data[:, :-1],  # use only xy data
     sizes=15,
     alpha=0.7,
@@ -30,7 +30,7 @@ scatter_graphic = figure[0, 0].add_scatter(
 
 figure.show()
 
-scatter_graphic.cmap = "tab10"
+scatter.cmap = "tab10"
 
 
 if __name__ == "__main__":

--- a/examples/scatter/scatter_colorslice.py
+++ b/examples/scatter/scatter_colorslice.py
@@ -40,11 +40,11 @@ figure[0, 0].add_scatter(data=cloud, sizes=3, colors=colors, alpha=0.6)
 
 figure.show()
 
-scatter_graphic = figure[0, 0].graphics[0]
+scatter = figure[0, 0].graphics[0]
 
-scatter_graphic.colors[0:75] = "red"
-scatter_graphic.colors[75:150] = "white"
-scatter_graphic.colors[::2] = "blue"
+scatter.colors[0:75] = "red"
+scatter.colors[75:150] = "white"
+scatter.colors[::2] = "blue"
 
 # NOTE: fpl.loop.run() should not be used for interactive sessions
 # See the "JupyterLab and IPython" section in the user guide

--- a/examples/scatter/scatter_colorslice_iris.py
+++ b/examples/scatter/scatter_colorslice_iris.py
@@ -19,7 +19,7 @@ data = datasets.load_iris()["data"]
 n_points = 50
 colors = ["yellow"] * n_points + ["cyan"] * n_points + ["magenta"] * n_points
 
-scatter_graphic = figure[0, 0].add_scatter(
+scatter = figure[0, 0].add_scatter(
     data=data[:, :-1],
     sizes=6,
     alpha=0.7,
@@ -28,9 +28,9 @@ scatter_graphic = figure[0, 0].add_scatter(
 
 figure.show()
 
-scatter_graphic.colors[0:75] = "red"
-scatter_graphic.colors[75:150] = "white"
-scatter_graphic.colors[::2] = "blue"
+scatter.colors[0:75] = "red"
+scatter.colors[75:150] = "white"
+scatter.colors[::2] = "blue"
 
 
 if __name__ == "__main__":

--- a/examples/scatter/scatter_dataslice_iris.py
+++ b/examples/scatter/scatter_dataslice_iris.py
@@ -20,16 +20,16 @@ data = datasets.load_iris()["data"]
 n_points = 50
 colors = ["yellow"] * n_points + ["cyan"] * n_points + ["magenta"] * n_points
 
-scatter_graphic = figure[0, 0].add_scatter(data=data[:, :-1], sizes=6, alpha=0.7, colors=colors)
+scatter = figure[0, 0].add_scatter(data=data[:, :-1], sizes=6, alpha=0.7, colors=colors)
 
 figure.show()
 
-scatter_graphic.data[0] = np.array([[5, 3, 1.5]])
-scatter_graphic.data[1] = np.array([[4.3, 3.2, 1.3]])
-scatter_graphic.data[2] = np.array([[5.2, 2.7, 1.7]])
+scatter.data[0] = np.array([[5, 3, 1.5]])
+scatter.data[1] = np.array([[4.3, 3.2, 1.3]])
+scatter.data[2] = np.array([[5.2, 2.7, 1.7]])
 
-scatter_graphic.data[10:15] = scatter_graphic.data[0:5] + np.array([1, 1, 1])
-scatter_graphic.data[50:100:2] = scatter_graphic.data[100:150:2] + np.array([1, 1, 0])
+scatter.data[10:15] = scatter.data[0:5] + np.array([1, 1, 1])
+scatter.data[50:100:2] = scatter.data[100:150:2] + np.array([1, 1, 0])
 
 
 if __name__ == "__main__":

--- a/examples/scatter/scatter_iris.py
+++ b/examples/scatter/scatter_iris.py
@@ -23,7 +23,7 @@ data = np.load(data_path)
 n_points = 50
 colors = ["yellow"] * n_points + ["cyan"] * n_points + ["magenta"] * n_points
 
-scatter_graphic = figure[0, 0].add_scatter(data=data[:, :-1], sizes=6, alpha=0.7, colors=colors)
+scatter = figure[0, 0].add_scatter(data=data[:, :-1], sizes=6, alpha=0.7, colors=colors)
 
 figure.show()
 

--- a/examples/selection_tools/linear_region_selector.py
+++ b/examples/selection_tools/linear_region_selector.py
@@ -37,22 +37,22 @@ xs = np.linspace(0, 200 * np.pi, 10_000)
 ys = np.sin(xs) + np.random.normal(scale=0.2, size=10000)
 
 # make sine along x axis
-sine_graphic_x = figure[0, 0].add_line(np.column_stack([xs, ys]), thickness=1)
+sine_x = figure[0, 0].add_line(np.column_stack([xs, ys]), thickness=1)
 
 # x = sine(y), sine(y) > 0 = 0
-sine_y = ys
-sine_y[sine_y > 0] = 0
+sine_y_data = ys
+sine_y_data[sine_y_data > 0] = 0
 
 # sine along y axis
-sine_graphic_y = figure[0, 1].add_line(np.column_stack([ys, xs]))
+sine_y = figure[0, 1].add_line(np.column_stack([ys, xs]))
 
 # offset the position of the graphic to demonstrate `get_selected_data()` later
-sine_graphic_y.position_x = 50
-sine_graphic_y.position_y = 50
+sine_y.position_x = 50
+sine_y.position_y = 50
 
 # add linear selectors
-selector_x = sine_graphic_x.add_linear_region_selector((0, 100))  # default axis is "x"
-selector_y = sine_graphic_y.add_linear_region_selector(axis="y")
+selector_x = sine_x.add_linear_region_selector((0, 100))  # default axis is "x"
+selector_y = sine_y.add_linear_region_selector(axis="y")
 
 # preallocate array for storing zoomed in data
 zoomed_init = np.column_stack([np.arange(zoomed_prealloc), np.zeros(zoomed_prealloc)])

--- a/examples/selection_tools/linear_region_selectors_match_offsets.py
+++ b/examples/selection_tools/linear_region_selectors_match_offsets.py
@@ -32,22 +32,22 @@ xs = np.linspace(0, 10 * np.pi, 1_000)
 ys = np.sin(xs)  # y = sine(x)
 
 # make sine along x axis
-sine_graphic_x = figure[0, 0].add_line(np.column_stack([xs, ys]), offset=(10, 10, 0))
+sine_x = figure[0, 0].add_line(np.column_stack([xs, ys]), offset=(10, 10, 0))
 
 # x = sine(y), sine(y) > 0 = 0
-sine_y = ys
-sine_y[sine_y > 0] = 0
+sine_y_data = ys
+sine_y_data[sine_y_data > 0] = 0
 
 # sine along y axis
-sine_graphic_y = figure[0, 1].add_line(np.column_stack([ys, xs]), offset=(10, 10, 0))
+sine_y = figure[0, 1].add_line(np.column_stack([ys, xs]), offset=(10, 10, 0))
 
 # offset the position of the graphic to demonstrate `get_selected_data()` later
-sine_graphic_y.position_x = 50
-sine_graphic_y.position_y = 50
+sine_y.position_x = 50
+sine_y.position_y = 50
 
 # add linear selectors
-selector_x = sine_graphic_x.add_linear_region_selector()  # default axis is "x"
-selector_y = sine_graphic_y.add_linear_region_selector(axis="y")
+selector_x = sine_x.add_linear_region_selector()  # default axis is "x"
+selector_y = sine_y.add_linear_region_selector(axis="y")
 
 # preallocate array for storing zoomed in data
 zoomed_init = np.column_stack([np.arange(zoomed_prealloc), np.zeros(zoomed_prealloc)])

--- a/examples/selection_tools/rectangle_selector_zoom.py
+++ b/examples/selection_tools/rectangle_selector_zoom.py
@@ -18,10 +18,10 @@ figure = fpl.Figure(
 )
 
 # add image
-image_graphic = figure[0, 0].add_image(data=iio.imread("imageio:camera.png"))
+image = figure[0, 0].add_image(data=iio.imread("imageio:camera.png"))
 
 # add rectangle selector to image graphic
-rectangle_selector = image_graphic.add_rectangle_selector()
+rectangle_selector = image.add_rectangle_selector()
 
 # add a zoomed plot of the selected data
 zoom_ig = figure[1, 0].add_image(rectangle_selector.get_selected_data())

--- a/examples/selection_tools/unit_circle.py
+++ b/examples/selection_tools/unit_circle.py
@@ -67,15 +67,15 @@ figure["cos(x)"].camera.maintain_aspect = False
 
 # create sine and cosine data
 xs = np.linspace(0, 2 * np.pi, 360)
-sine = np.sin(xs)
-cosine = np.cos(xs)
+sine_data = np.sin(xs)
+cosine_data = np.cos(xs)
 
 # circle data
 circle_data = make_circle(center=(0, 0), radius=1, n_points=360)
 
 # make the circle line graphic, set the cmap transform using the sine function
-circle_graphic = figure["unit circle"].add_line(
-    circle_data, thickness=4, cmap="bwr", cmap_transform=sine
+circle = figure["unit circle"].add_line(
+    circle_data, thickness=4, cmap="bwr", cmap_transform=sine_data
 )
 
 # line to show the circle radius
@@ -86,36 +86,36 @@ circle_radius = figure["unit circle"].add_line(
 )
 
 # sine line graphic, cmap transform set from the sine function
-sine_graphic = figure["sin(x)"].add_line(
-    sine, thickness=10, cmap="bwr", cmap_transform=sine
+sine = figure["sin(x)"].add_line(
+    sine_data, thickness=10, cmap="bwr", cmap_transform=sine_data
 )
 
 # cosine line graphic, cmap transform set from the sine function
 # illustrates the sine function values on the cosine graphic
-cosine_graphic = figure["cos(x)"].add_line(
-    cosine, thickness=10, cmap="bwr", cmap_transform=sine
+cosine = figure["cos(x)"].add_line(
+    cosine_data, thickness=10, cmap="bwr", cmap_transform=sine_data
 )
 
 # add linear selectors to the sine and cosine line graphics
-sine_selector = sine_graphic.add_linear_selector()
-cosine_selector = cosine_graphic.add_linear_selector()
+sine_selector = sine.add_linear_selector()
+cosine_selector = cosine.add_linear_selector()
 
 
 def set_circle_cmap(ev):
     # sets the cmap transforms
 
     cmap_transform = ev.graphic.data[:, 1]  # y-val data of the sine or cosine graphic
-    for g in [sine_graphic, cosine_graphic]:
+    for g in [sine, cosine]:
         g.cmap.transform = cmap_transform
 
     # set circle cmap transform
-    circle_graphic.cmap.transform = cmap_transform
+    circle.cmap.transform = cmap_transform
 
 # when the sine or cosine graphic is clicked, the cmap_transform
 # of the sine, cosine and circle line graphics are all set from
 # the y-values of the clicked line
-sine_graphic.add_event_handler(set_circle_cmap, "click")
-cosine_graphic.add_event_handler(set_circle_cmap, "click")
+sine.add_event_handler(set_circle_cmap, "click")
+cosine.add_event_handler(set_circle_cmap, "click")
 
 
 def set_x_val(ev):


### PR DESCRIPTION
Removing `_graphic` suffix when creating graphics in examples to declutter things 