### PR TITLE
Refactor z-order to ensure axes are on top

### DIFF
--- a/examples/gridplot/gridplot.py
+++ b/examples/gridplot/gridplot.py
@@ -10,20 +10,31 @@ Example showing simple 2x2 grid layout with standard images from imageio.
 
 import fastplotlib as fpl
 import imageio.v3 as iio
+import numpy as np
 
 figure = fpl.Figure(shape=(2, 2), size=(700, 560))
 
-im = iio.imread("imageio:clock.png")
-im2 = iio.imread("imageio:astronaut.png")
+im1 = iio.imread("imageio:clock.png")
+im2 = iio.imread("imageio:astronaut.png")[:500,:300]
 im3 = iio.imread("imageio:coffee.png")
 im4 = iio.imread("imageio:hubble_deep_field.png")
 
-figure[0, 0].add_image(data=im)
-figure[0, 1].add_image(data=im2)
+xs = np.linspace(-10, 10, 100)
+a = 0.5
+ys = np.sinc(xs) * 3 + 8
+sinc_data = np.column_stack([xs, ys])
+
+i1=figure[0, 0].add_image(data=im1)
+i2=figure[0, 0].add_image(data=im2)
 figure[1, 0].add_image(data=im3)
-figure[1, 1].add_image(data=im4)
+x = figure[1, 1].add_line(sinc_data,  thickness=12, cmap="autumn")
+y = figure[1, 1].add_line(sinc_data,  thickness=2, cmap="jet")
 
 figure.show()
+
+
+r = figure[0,1].scene.children[2].children[0]
+i = figure[0,1].graphics[0].world_object.children[0]
 
 
 # NOTE: fpl.loop.run() should not be used for interactive sessions

--- a/fastplotlib/graphics/_axes.py
+++ b/fastplotlib/graphics/_axes.py
@@ -183,14 +183,22 @@ class Axes:
         }
 
         # create ruler for each dim
-        self._x = pygfx.Ruler(alpha_mode="solid", **x_kwargs)
-        self._y = pygfx.Ruler(alpha_mode="solid", **y_kwargs)
-        self._z = pygfx.Ruler(alpha_mode="solid", **z_kwargs)
+        self._x = pygfx.Ruler(
+            alpha_mode="solid", render_queue=RenderQueue.axes, **x_kwargs
+        )
+        self._y = pygfx.Ruler(
+            alpha_mode="solid", render_queue=RenderQueue.axes, **y_kwargs
+        )
+        self._z = pygfx.Ruler(
+            alpha_mode="solid", render_queue=RenderQueue.axes, **z_kwargs
+        )
 
         # We render the lines and ticks as solid, but enable aa for text for prettier glyphs
         for ruler in self._x, self._y, self._z:
+            ruler.line.material.depth_compare = "<="
+            ruler.points.material.depth_compare = "<="
+            ruler.text.material.depth_compare = "<="
             ruler.text.material.alpha_mode = "auto"
-            ruler.text.material.render_queue = RenderQueue.auto + 50
             ruler.text.material.aa = True
 
         self._offset = offset

--- a/fastplotlib/graphics/image.py
+++ b/fastplotlib/graphics/image.py
@@ -324,9 +324,6 @@ class ImageGraphic(Graphic):
 
         self._plot_area.add_graphic(selector, center=False)
 
-        # place selector above this graphic
-        selector.offset = selector.offset + (0.0, 0.0, self.offset[-1] + 1)
-
         return selector
 
     def add_linear_region_selector(
@@ -402,9 +399,6 @@ class ImageGraphic(Graphic):
 
         self._plot_area.add_graphic(selector, center=False)
 
-        # place above this graphic
-        selector.offset = selector.offset + (0.0, 0.0, self.offset[-1] + 1)
-
         return selector
 
     def add_rectangle_selector(
@@ -447,9 +441,6 @@ class ImageGraphic(Graphic):
 
         self._plot_area.add_graphic(selector, center=False)
 
-        # place above this graphic
-        selector.offset = selector.offset + (0.0, 0.0, self.offset[-1] + 1)
-
         return selector
 
     def add_polygon_selector(
@@ -484,8 +475,5 @@ class ImageGraphic(Graphic):
         )
 
         self._plot_area.add_graphic(selector, center=False)
-
-        # place above this graphic
-        selector.offset = selector.offset + (0.0, 0.0, self.offset[-1] + 1)
 
         return selector

--- a/fastplotlib/graphics/line.py
+++ b/fastplotlib/graphics/line.py
@@ -179,9 +179,6 @@ class LineGraphic(PositionsGraphic):
 
         self._plot_area.add_graphic(selector, center=False)
 
-        # place selector above this graphic
-        selector.offset = selector.offset + (0.0, 0.0, self.offset[-1] + 1)
-
         return selector
 
     def add_linear_region_selector(
@@ -237,9 +234,6 @@ class LineGraphic(PositionsGraphic):
         )
 
         self._plot_area.add_graphic(selector, center=False)
-
-        # place selector below this graphic
-        selector.offset = selector.offset + (0.0, 0.0, self.offset[-1] - 1)
 
         # PlotArea manages this for garbage collection etc. just like all other Graphics
         # so we should only work with a proxy on the user-end

--- a/fastplotlib/graphics/line.py
+++ b/fastplotlib/graphics/line.py
@@ -95,13 +95,16 @@ class LineGraphic(PositionsGraphic):
         self._thickness = Thickness(thickness)
 
         if thickness < 1.1:
+            MaterialCls = pygfx.LineThinMaterial
             aa = True
         else:
-            aa = kwargs.get("alpha_mode", "auto") in ("blend", "weighted_blend")
+            MaterialCls = pygfx.LineMaterial
+
+        aa = kwargs.get("alpha_mode", "auto") in ("blend", "weighted_blend")
 
         if uniform_color:
             geometry = pygfx.Geometry(positions=self._data.buffer)
-            material = pygfx.LineMaterial(
+            material = MaterialCls(
                 aa=aa,
                 thickness=self.thickness,
                 color_mode="uniform",
@@ -111,7 +114,7 @@ class LineGraphic(PositionsGraphic):
                 depth_compare="<=",
             )
         else:
-            material = pygfx.LineMaterial(
+            material = MaterialCls(
                 aa=aa,
                 thickness=self.thickness,
                 color_mode="vertex",

--- a/fastplotlib/graphics/line.py
+++ b/fastplotlib/graphics/line.py
@@ -95,29 +95,29 @@ class LineGraphic(PositionsGraphic):
         self._thickness = Thickness(thickness)
 
         if thickness < 1.1:
-            MaterialCls = pygfx.LineThinMaterial
+            aa = True
         else:
-            MaterialCls = pygfx.LineMaterial
-
-        aa = kwargs.get("alpha_mode", "auto") in ("blend", "weighted_blend")
+            aa = kwargs.get("alpha_mode", "auto") in ("blend", "weighted_blend")
 
         if uniform_color:
             geometry = pygfx.Geometry(positions=self._data.buffer)
-            material = MaterialCls(
+            material = pygfx.LineMaterial(
                 aa=aa,
                 thickness=self.thickness,
                 color_mode="uniform",
                 color=self.colors,
                 pick_write=True,
                 thickness_space=self.size_space,
+                depth_compare="<=",
             )
         else:
-            material = MaterialCls(
+            material = pygfx.LineMaterial(
                 aa=aa,
                 thickness=self.thickness,
                 color_mode="vertex",
                 pick_write=True,
                 thickness_space=self.size_space,
+                depth_compare="<=",
             )
             geometry = pygfx.Geometry(
                 positions=self._data.buffer, colors=self._colors.buffer

--- a/fastplotlib/graphics/line_collection.py
+++ b/fastplotlib/graphics/line_collection.py
@@ -378,9 +378,6 @@ class LineCollection(GraphicCollection, _LineCollectionProperties):
 
         self._plot_area.add_graphic(selector, center=False)
 
-        # place selector above this graphic
-        selector.offset = selector.offset + (0.0, 0.0, self.offset[-1] + 1)
-
         return selector
 
     def add_linear_region_selector(
@@ -434,9 +431,6 @@ class LineCollection(GraphicCollection, _LineCollectionProperties):
         )
 
         self._plot_area.add_graphic(selector, center=False)
-
-        # place selector below this graphic
-        selector.offset = selector.offset + (0.0, 0.0, self.offset[-1] - 1)
 
         # PlotArea manages this for garbage collection etc. just like all other Graphics
         # so we should only work with a proxy on the user-end

--- a/fastplotlib/graphics/scatter.py
+++ b/fastplotlib/graphics/scatter.py
@@ -97,10 +97,7 @@ class ScatterGraphic(PositionsGraphic):
         aa = kwargs.get("alpha_mode", "auto") in ("blend", "weighted_blend")
 
         geo_kwargs = {"positions": self._data.buffer}
-        material_kwargs = dict(
-            pick_write=True,
-            aa=aa,
-        )
+        material_kwargs = dict(pick_write=True, aa=aa, depth_compare="<=")
         self._size_space = SizeSpace(size_space)
 
         if uniform_color:

--- a/fastplotlib/legends/legend.py
+++ b/fastplotlib/legends/legend.py
@@ -112,7 +112,6 @@ class LineLegendItem(LegendItem):
         self._label_world_object.world.x = position[0] + 10
 
         self.world_object.world.y = position[1]
-        self.world_object.world.z = 2
 
         self.world_object.add_event_handler(
             partial(self._highlight_graphic, graphic), "click"

--- a/fastplotlib/legends/legend.py
+++ b/fastplotlib/legends/legend.py
@@ -71,11 +71,9 @@ class LineLegendItem(LegendItem):
         # construct Line WorldObject
         data = np.array([[0, 0, 0], [3, 0, 0]], dtype=np.float32)
 
-        material = pygfx.LineMaterial
-
         self._line_world_object = pygfx.Line(
             geometry=pygfx.Geometry(positions=data),
-            material=material(
+            material=pygfx.LineMaterial(
                 alpha_mode="blend",
                 render_queue=RenderQueue.overlay,
                 thickness=8,

--- a/fastplotlib/utils/enums.py
+++ b/fastplotlib/utils/enums.py
@@ -9,6 +9,7 @@ class RenderQueue(IntEnum):
     auto = 2600
     transparent = 3000
     overlay = 4000
-    # For selectors we use a render_queue of 3500, which is at the end of what is considered the group of transparent objects.
-    # So it's rendered later than the normal scene (2000 - 3000), but before overlays like legends and tooltips.
-    selector = 3500
+    # For axes and selectors we use a higher render_queue, so they get rendered later than
+    # the graphics. Axes (rulers) have depth_compare '<=' and selectors don't compare depth.
+    axes = 3400  # still in 'object' group
+    selector = 3600  # considered in 'overlay' group


### PR DESCRIPTION
Closes #903

* [x] Graphics are no longer offset in depth, because the depth may actually mean something.
* [x] Except ImageGraphics, they are now pushed back (older further away).
* [x] Lines, points, and axes use `depth_campare="<="` so that for objects at the same depth, the render order determines which one is on top.  
* [x] Set `render_queue`  of axes so they are rendered later than all the other objects.

This should make it that axes and graphics interact as expected in both 3D and 2D scenes. Note that in a 2D view (panzoom controller), if a scatter graphic has data that is nonzero for z, it can indeed cover the axes, but this is expected.