### PR TITLE
thinner selectors

### DIFF
--- a/examples/selection_tools/linear_selector.py
+++ b/examples/selection_tools/linear_selector.py
@@ -2,7 +2,8 @@
 Linear Selectors
 ================
 
-Example showing how to use a `LinearSelector` with lines and line collections.
+Example showing how to use a `LinearSelector` with lines and line collections. The linear selector is the yellow
+vertical line.
 """
 
 # test_example = true

--- a/examples/selection_tools/linear_selector_image.py
+++ b/examples/selection_tools/linear_selector_image.py
@@ -2,8 +2,9 @@
 Linear Selectors Image
 ======================
 
-Example showing how to use a `LinearSelector` to selector rows or columns of an image. The subplot on the right
-displays the data for the selector row and column.
+Example showing how to use a `LinearSelector` to select rows or columns of an image. The subplot on the right
+displays the data for the selector row and column. Move the selectors independently or click the middle mouse
+button to move both selectors to the clicked location.
 """
 
 # test_example = false
@@ -24,10 +25,10 @@ figure = fpl.Figure(
 image = figure[0, 0].add_image(image_data)
 
 # add a row selector
-image_row_selector = image.add_linear_selector(axis="y")
+image_row_selector = image.add_linear_selector(axis="y", edge_color="cyan")
 
 # add column selector
-image_col_selector = image.add_linear_selector()
+image_col_selector = image.add_linear_selector(edge_color="cyan")
 
 # make a line to indicate row data
 line_image_row = figure[0, 1].add_line(image.data[0])

--- a/examples/selection_tools/unit_circle.py
+++ b/examples/selection_tools/unit_circle.py
@@ -132,6 +132,9 @@ def set_x_val(ev):
 sine_selector.add_event_handler(set_x_val, "selection")
 cosine_selector.add_event_handler(set_x_val, "selection")
 
+# set initial position of the selector so it's not just overlapping the y-axis
+sine_selector.selection = 100
+
 figure.show()
 
 

--- a/fastplotlib/graphics/features/_selection_features.py
+++ b/fastplotlib/graphics/features/_selection_features.py
@@ -64,9 +64,9 @@ class LinearSelectionFeature(GraphicFeature):
         elif self._axis == "y":
             dim = 1
 
-        for edge in selector._edges:
-            edge.geometry.positions.data[:, dim] = value
-            edge.geometry.positions.update_range()
+        edge = selector._edges[0]
+        edge.geometry.positions.data[:, dim] = value
+        edge.geometry.positions.update_range()
 
         self._value = value
 
@@ -152,10 +152,10 @@ class LinearRegionSelectionFeature(GraphicFeature):
             selector.fill.geometry.positions.data[mesh_masks.x_right] = value[1]
 
             # change x position of the left edge line
-            selector.edges[0].geometry.positions.data[:, 0] = value[0]
+            selector._edges[0].geometry.positions.data[:, 0] = value[0]
 
             # change x position of the right edge line
-            selector.edges[1].geometry.positions.data[:, 0] = value[1]
+            selector._edges[1].geometry.positions.data[:, 0] = value[1]
 
         elif self.axis == "y":
             # change bottom y position of the fill mesh
@@ -165,18 +165,18 @@ class LinearRegionSelectionFeature(GraphicFeature):
             selector.fill.geometry.positions.data[mesh_masks.y_top] = value[1]
 
             # change y position of the bottom edge line
-            selector.edges[0].geometry.positions.data[:, 1] = value[0]
+            selector._edges[0].geometry.positions.data[:, 1] = value[0]
 
             # change y position of the top edge line
-            selector.edges[1].geometry.positions.data[:, 1] = value[1]
+            selector._edges[1].geometry.positions.data[:, 1] = value[1]
 
         self._value = value
 
         # send changes to GPU
         selector.fill.geometry.positions.update_range()
 
-        selector.edges[0].geometry.positions.update_range()
-        selector.edges[1].geometry.positions.update_range()
+        selector._edges[0].geometry.positions.update_range()
+        selector._edges[1].geometry.positions.update_range()
 
         # send event
         if len(self._event_handlers) < 1:

--- a/fastplotlib/graphics/selectors/_linear.py
+++ b/fastplotlib/graphics/selectors/_linear.py
@@ -78,9 +78,10 @@ class LinearSelector(BaseSelector):
         limits: Sequence[float],
         axis: str = "x",
         parent: Graphic = None,
-        edge_color: str | Sequence[float] | np.ndarray = "w",
-        thickness: float = 2.5,
+        edge_color: str | Sequence[float] | np.ndarray = "yellow",
+        thickness: float = 1.0,
         arrow_keys_modifier: str = "Shift",
+        extra_width: float = 14.0,
         name: str = None,
     ):
         """
@@ -110,6 +111,9 @@ class LinearSelector(BaseSelector):
 
         edge_color: str | tuple | np.ndarray, default "w"
             color of the selector
+
+        extra_width: float, default 14.0
+            the width around the selector which is responsive to mouse events, in logical pixels
 
         name: str, optional
             name of linear selector
@@ -141,8 +145,6 @@ class LinearSelector(BaseSelector):
 
         material = pygfx.LineInfiniteSegmentMaterial
 
-        self.colors_outer = pygfx.Color([0.3, 0.3, 0.3, 1.0])
-
         line_inner = pygfx.Line(
             # self.data.feature_data because data is a Buffer
             geometry=pygfx.Geometry(positions=line_data),
@@ -158,11 +160,12 @@ class LinearSelector(BaseSelector):
             ),
         )
 
-        self.line_outer = pygfx.Line(
-            geometry=pygfx.Geometry(positions=line_data),
+        line_outer = pygfx.Line(
+            geometry=line_inner.geometry,
             material=material(
-                thickness=thickness + 6,
-                color=self.colors_outer,
+                thickness=thickness + extra_width,
+                color=pygfx.Color([0, 0, 0]),
+                opacity=0,
                 alpha_mode="blend",
                 aa=True,
                 render_queue=RenderQueue.selector,
@@ -177,7 +180,7 @@ class LinearSelector(BaseSelector):
 
         world_object = pygfx.Group()
 
-        world_object.add(self.line_outer)
+        world_object.add(line_outer)
         world_object.add(line_inner)
 
         if axis == "x":
@@ -188,8 +191,9 @@ class LinearSelector(BaseSelector):
         # init base selector
         BaseSelector.__init__(
             self,
-            edges=(line_inner, self.line_outer),
-            hover_responsive=(line_inner, self.line_outer),
+            edges=(line_inner,),
+            outer_edges=(line_outer,),
+            hover_responsive=(line_inner,),
             arrow_keys_modifier=arrow_keys_modifier,
             axis=axis,
             parent=parent,

--- a/fastplotlib/tools/_histogram_lut.py
+++ b/fastplotlib/tools/_histogram_lut.py
@@ -106,7 +106,6 @@ class HistogramLUTTool(Graphic):
             size=size,
             center=origin[0],
             axis="y",
-            edge_thickness=8,
             parent=self._histogram_line,
         )
 


### PR DESCRIPTION
After the alpha refactor by @almarklein this is finally possible! I think this looks much better, the width of the outer transparent line is a kwarg `hitbox_width`

https://github.com/user-attachments/assets/985da684-2585-4b1b-929d-e82be0956d87

https://github.com/user-attachments/assets/99bb7692-b270-40fe-a5d6-2a117fa51ea2

superseeds #904