### PR TITLE
skip existing arrays in ImageWidget.set_data()

### DIFF
--- a/fastplotlib/widgets/image_widget/_widget.py
+++ b/fastplotlib/widgets/image_widget/_widget.py
@@ -929,6 +929,11 @@ class ImageWidget:
         for i, (new_array, current_array, subplot) in enumerate(
             zip(new_data, self._data, self.figure)
         ):
+            # if the new array is the same as the existing array, skip
+            # this allows setting just a subset of the arrays in the ImageWidget
+            if new_data is self._data[i]:
+                continue
+
             # check last two dims (x and y) to see if data shape is changing
             old_data_shape = self._data[i].shape[-self.n_img_dims[i] :]
             self._data[i] = new_array


### PR DESCRIPTION
Skips data arrays that already exist, closes #901 

@clewis7 should be gtg
