### PR TITLE
bugfix processors type

### DIFF
--- a/fastplotlib/widgets/image_widget/_widget.py
+++ b/fastplotlib/widgets/image_widget/_widget.py
@@ -116,7 +116,7 @@ class ImageWidget:
                 f"You have passed the following type {type(data)}"
             )
 
-        if issubclass(processors, NDImageProcessor):
+        if isinstance(processors, type) and issubclass(processors, NDImageProcessor):
             processors = [processors] * len(data)
 
         elif isinstance(processors, (tuple, list)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords = [
 requires-python = ">= 3.10"
 dependencies = [
     "numpy>=1.23.0",
-    "pygfx==0.15",
+    "pygfx==0.15.2",
     "wgpu",          # Let pygfx constrain the wgpu version
     "cmap>=0.1.3",
     # (this comment keeps this list multiline in VSCode)


### PR DESCRIPTION
```
issubclass(processors, NDImageProcessor):
```
Fails for sequences. Since all class instances are of type `type`, this makes sense to me over a try/except:

```
try:
    if issubclass(processors, NDImageProcessor):
        processors = [processors] * len(data)
except TypeError:
    if isinstance(processors, (tuple, list)):
        ...
```