### PR TITLE
Update installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,31 +63,28 @@ Questions, issues, ideas? You are welcome to post an [issue](https://github.com/
 
 To install use pip:
 
-```bash
-# with imgui and jupyterlab
-pip install -U "fastplotlib[notebook,imgui]"
+### With imgui support (recommended)
 
-# minimal install, install glfw, pyqt6 or pyside6 separately
-pip install -U fastplotlib
+Without jupyterlab support, install desired GUI framework such as glfw, PyQt6, or PySide6 separately.
 
-# with imgui
-pip install -U "fastplotlib[imgui]"
+    pip install -U "fastplotlib[imgui]"
 
-# to use in jupyterlab without imgui
-pip install -U "fastplotlib[notebook]"
-```
+With jupyterlab support.
 
-We strongly recommend installing ``simplejpeg`` for use in notebooks, you must first install [libjpeg-turbo](https://libjpeg-turbo.org/)
+    pip install -U "fastplotlib[notebook,imgui]"
 
-- If you use ``conda``, you can get ``libjpeg-turbo`` through conda.
-- If you are on linux, you can get it through your distro's package manager.
-- For Windows and Mac compiled binaries are available on their release page: https://github.com/libjpeg-turbo/libjpeg-turbo/releases
+### Without imgui
 
-Once you have ``libjpeg-turbo``:
+Minimal, install desired GUI library such as PyQt6, PySide6, or glfw separately.
 
-```bash
-pip install simplejpeg
-```
+    pip install fastplotlib
+
+With jupyterlab support only.
+
+    pip install -U "fastplotlib[notebook]"
+
+Fastplotlib is also available on conda-forge. For imgui support you will need to separately install `imgui-bundle`, and for jupyterlab you will need to install `jupyter-rfb` and `simplejpeg` which are all available on conda-forge.
+
 
 > **Note:**
 > `fastplotlib` and `pygfx` are fast evolving projects, the version available through pip might be outdated, you will need to follow the "For developers" instructions below if you want the latest features. You can find the release history here: https://github.com/fastplotlib/fastplotlib/releases

--- a/docs/source/user_guide/guide.rst
+++ b/docs/source/user_guide/guide.rst
@@ -36,6 +36,8 @@ With jupyterlab support only.
 
     pip install -U "fastplotlib[notebook]"
 
+Fastplotlib is also available on conda-forge. For imgui support you will need to separately install ``imgui-bundle``, and for jupyterlab you will need to install ``jupyter-rfb`` and ``simplejpeg`` which are all available on conda-forge.
+
 
 What is ``fastplotlib``?
 ------------------------

--- a/docs/source/user_guide/guide.rst
+++ b/docs/source/user_guide/guide.rst
@@ -6,31 +6,36 @@ Installation
 
 To install use pip:
 
+With imgui support (recommended)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Without jupyterlab support, install desired GUI framework such as glfw, PyQt6, or PySide6 separately.
+
 .. code-block::
 
-    # with imgui and jupyterlab
-    pip install -U "fastplotlib[notebook,imgui]"
-
-    # minimal install, install glfw, pyqt6 or pyside6 separately
-    pip install -U fastplotlib
-
-    # with imgui
     pip install -U "fastplotlib[imgui]"
 
-    # to use in jupyterlab, no imgui
-    pip install -U "fastplotlib[notebook]"
-
-We strongly recommend installing ``simplejpeg`` for use in notebooks, you must first install `libjpeg-turbo <https://libjpeg-turbo.org/>`_.
-
-- If you use ``conda``, you can get ``libjpeg-turbo`` through conda.
-- If you are on linux you can get it through your distro's package manager.
-- For Windows and Mac compiled binaries are available on their release page: https://github.com/libjpeg-turbo/libjpeg-turbo/releases
-
-Once you have ``libjpeg-turbo``:
+With jupyterlab support.
 
 .. code-block::
 
-    pip install simplejpeg
+    pip install -U "fastplotlib[notebook,imgui]"
+
+Without imgui
+^^^^^^^^^^^^^
+
+Minimal, install desired GUI library such as PyQt6, PySide6, or glfw separately.
+
+.. code-block::
+
+    pip install fastplotlib
+
+With jupyterlab support only.
+
+.. code-block::
+
+    pip install -U "fastplotlib[notebook]"
+
 
 What is ``fastplotlib``?
 ------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ notebook = [
     "jupyter-rfb>=0.5.1",
     "ipywidgets>=8.0.0,<9",
     "sidecar",
+    "simplejpeg",
 ]
 tests = [
     "pytest",


### PR DESCRIPTION
organize the installation docs, and `simplejpeg` can just be a notebook dependency. It also seems like a separate install of libturbojpeg isn't required: https://github.com/jfolz/simplejpeg?tab=readme-ov-file#installation

Merging into `ndwidget` branch since I have to update the install instructions there as well with the `ndwidget` toggle 