### PR TITLE
`Figure` can accept `rects` or `extents` as an `dict` with keys indicating subplot names

### DIFF
--- a/fastplotlib/layouts/_figure.py
+++ b/fastplotlib/layouts/_figure.py
@@ -27,8 +27,12 @@ class Figure:
     def __init__(
         self,
         shape: tuple[int, int] = (1, 1),
-        rects: list[tuple | np.ndarray] | OrderedDict[str, tuple | np.ndarray | list] = None,
-        extents: list[tuple | np.ndarray] | OrderedDict[str, tuple | np.ndarray | list] = None,
+        rects: (
+            list[tuple | np.ndarray] | OrderedDict[str, tuple | np.ndarray | list]
+        ) = None,
+        extents: (
+            list[tuple | np.ndarray] | OrderedDict[str, tuple | np.ndarray | list]
+        ) = None,
         cameras: (
             Literal["2d", "3d"]
             | Iterable[Iterable[Literal["2d", "3d"]]]

--- a/fastplotlib/layouts/_figure.py
+++ b/fastplotlib/layouts/_figure.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from inspect import getfullargspec
 from itertools import product, chain
 import os
@@ -27,12 +26,8 @@ class Figure:
     def __init__(
         self,
         shape: tuple[int, int] = (1, 1),
-        rects: (
-            list[tuple | np.ndarray] | OrderedDict[str, tuple | np.ndarray | list]
-        ) = None,
-        extents: (
-            list[tuple | np.ndarray] | OrderedDict[str, tuple | np.ndarray | list]
-        ) = None,
+        rects: list[tuple | np.ndarray] | dict[str, tuple | np.ndarray] = None,
+        extents: list[tuple | np.ndarray] | dict[str, tuple | np.ndarray] = None,
         cameras: (
             Literal["2d", "3d"]
             | Iterable[Iterable[Literal["2d", "3d"]]]
@@ -64,7 +59,7 @@ class Figure:
         shape: tuple[int, int], default (1, 1)
             shape [n_rows, n_cols] that defines a grid of subplots
 
-        rects: list of tuples or arrays, or an OrderedDict mapping subplot name -> rect
+        rects: list of tuples or arrays, or a dict mapping subplot name -> rect
             list or dict of rects (x, y, width, height) that define the subplots.
             If it is a dict, the keys are used as the subplot names.
             rects can be defined in absolute pixels or as a fraction of the canvas.
@@ -72,7 +67,7 @@ class Figure:
             Conversely, if width & height > 1 the rect is assumed to be in absolute pixels.
             width & height must be > 0. Negative values are not allowed.
 
-        extents: list of tuples or arrays, or an OrderedDict mapping subplot name -> extent
+        extents: list of tuples or arrays, or a dict mapping subplot name -> extent
             list or dict of extents (xmin, xmax, ymin, ymax) that define the subplots.
             If it is a dict, the keys are used as the subplot names.
             extents can be defined in absolute pixels or as a fraction of the canvas.
@@ -154,9 +149,9 @@ class Figure:
         self._fpl_overlay_scene = pygfx.Scene()
 
         if rects is not None:
-            if isinstance(rects, OrderedDict):
+            if isinstance(rects, dict):
                 # the actual rects are the dict values, subplot names are the keys
-                rects, names = list(rects.values()), list(rects.keys())
+                names, rects = zip(*rects.items())
 
             if not all(isinstance(v, (np.ndarray, tuple, list)) for v in rects):
                 raise TypeError(
@@ -167,9 +162,9 @@ class Figure:
             extents = [None] * n_subplots
 
         elif extents is not None:
-            if isinstance(extents, OrderedDict):
+            if isinstance(extents, dict):
                 # the actual extents are the dict values, subplot names are the keys
-                extents, names = list(extents.values()), list(extents.keys())
+                names, extents = zip(*extents.items())
 
             if not all(isinstance(v, (np.ndarray, tuple, list)) for v in extents):
                 raise TypeError(

--- a/fastplotlib/layouts/_figure.py
+++ b/fastplotlib/layouts/_figure.py
@@ -1,14 +1,14 @@
-import os
-from itertools import product, chain
-from pathlib import Path
-
-import numpy as np
-from typing import Literal, Iterable
+from collections import OrderedDict
 from inspect import getfullargspec
+from itertools import product, chain
+import os
+from pathlib import Path
+from typing import Literal, Iterable
 from warnings import warn
 
-import pygfx
+import numpy as np
 
+import pygfx
 from rendercanvas import BaseRenderCanvas
 
 from ._utils import (
@@ -27,8 +27,8 @@ class Figure:
     def __init__(
         self,
         shape: tuple[int, int] = (1, 1),
-        rects: list[tuple | np.ndarray] = None,
-        extents: list[tuple | np.ndarray] = None,
+        rects: list[tuple | np.ndarray] | OrderedDict[str, tuple | np.ndarray | list] = None,
+        extents: list[tuple | np.ndarray] | OrderedDict[str, tuple | np.ndarray | list] = None,
         cameras: (
             Literal["2d", "3d"]
             | Iterable[Iterable[Literal["2d", "3d"]]]
@@ -60,15 +60,17 @@ class Figure:
         shape: tuple[int, int], default (1, 1)
             shape [n_rows, n_cols] that defines a grid of subplots
 
-        rects: list of tuples or arrays
-            list of rects (x, y, width, height) that define the subplots.
+        rects: list of tuples or arrays, or an OrderedDict mapping subplot name -> rect
+            list or dict of rects (x, y, width, height) that define the subplots.
+            If it is a dict, the keys are used as the subplot names.
             rects can be defined in absolute pixels or as a fraction of the canvas.
             If width & height <= 1 the rect is assumed to be fractional.
             Conversely, if width & height > 1 the rect is assumed to be in absolute pixels.
             width & height must be > 0. Negative values are not allowed.
 
-        extents: list of tuples or arrays
-            list of extents (xmin, xmax, ymin, ymax) that define the subplots.
+        extents: list of tuples or arrays, or an OrderedDict mapping subplot name -> extent
+            list or dict of extents (xmin, xmax, ymin, ymax) that define the subplots.
+            If it is a dict, the keys are used as the subplot names.
             extents can be defined in absolute pixels or as a fraction of the canvas.
             If xmax & ymax <= 1 the extent is assumed to be fractional.
             Conversely, if xmax & ymax > 1 the extent is assumed to be in absolute pixels.
@@ -120,7 +122,7 @@ class Figure:
             starting size of canvas in absolute pixels, default (500, 300)
 
         names: list or array of str, optional
-            subplot names
+            subplot names, ignored if extents or rects are provided as a dict
 
         """
         # create canvas and renderer
@@ -148,6 +150,10 @@ class Figure:
         self._fpl_overlay_scene = pygfx.Scene()
 
         if rects is not None:
+            if isinstance(rects, OrderedDict):
+                # the actual rects are the dict values, subplot names are the keys
+                rects, names = list(rects.values()), list(rects.keys())
+
             if not all(isinstance(v, (np.ndarray, tuple, list)) for v in rects):
                 raise TypeError(
                     f"rects must a list of arrays, tuples, or lists of rects (x, y, w, h), you have passed: {rects}"
@@ -157,6 +163,10 @@ class Figure:
             extents = [None] * n_subplots
 
         elif extents is not None:
+            if isinstance(extents, OrderedDict):
+                # the actual extents are the dict values, subplot names are the keys
+                extents, names = list(extents.values()), list(extents.keys())
+
             if not all(isinstance(v, (np.ndarray, tuple, list)) for v in extents):
                 raise TypeError(
                     f"extents must a list of arrays, tuples, or lists of extents (xmin, xmax, ymin, ymax), "


### PR DESCRIPTION
I found it tedious creating a lot of custom subplots with defined extents and then assigning names to them separately, easy to get lost:

```python
extents = [
    (0, 0.33, 0.0, 0.25),  # pmd
    (0.33, 0.66, 0.0, 0.25),  # ac
    (0.66, 1, 0.0, 0.5),  # beh left
    (0, 0.33, 0.25, 0.5),  # res
    (0.33, 0.66, 0.25, 0.5),  # bg
    (0.66, 1, 0.5, 1.0),  # beh right
    (0, 0.66, 0.5, 0.75),  # traces
    (0, 0.66, 0.75, 1),  # lightning pose ethogram
]
```

This PR allows rects or extents to be defined with a dict where keys are subplot names, much easier I think:

```python
extents = {
    "pmd": (0, 0.33, 0.0, 0.25),
    "ac": (0.33, 0.66, 0.0, 0.25)
    "res": (0, 0.33, 0.25, 0.5),
...
}
```

@clewis7 gtg if tests pass
