### PR TITLE
Includes option to synchronize reference index objects over a fixed s…

### DIFF
--- a/fastplotlib/widgets/nd_widget/_index.py
+++ b/fastplotlib/widgets/nd_widget/_index.py
@@ -167,6 +167,9 @@ class ReferenceIndex:
 
         self._ndwidgets: list[NDWidget] = list()
 
+        self._blocked = False
+        self._synchronized_indices: dict[str, set[str]] = dict()
+
     @property
     def ref_ranges(self) -> dict[str, RangeContinuous | RangeDiscrete]:
         return self._ref_ranges
@@ -184,11 +187,68 @@ class ReferenceIndex:
         self._ndwidgets.append(ndw)
 
     def set(self, indices: dict[str, Any]):
-        for dim, value in indices.items():
-            self._indices[dim] = self._clamp(dim, value)
+        if not self.blocked:
+            for dim, value in indices.items():
+                self._check_has_dim(dim)
+                self._indices[dim] = self._clamp(dim, value)
 
-        self._render_indices()
-        self._indices_changed()
+            #Avoid re-entrance
+            self.blocked = True
+            #Make a list of synchronized ref index objects that are affected by the above change
+            updated_dims = indices.keys()
+            for ref_idx in self._synchronized_indices:
+                curr_dims_update = updated_dims & self._synchronized_indices[ref_idx]
+                if not curr_dims_update:
+                    continue
+                else:
+                    update_dict = {temp_dim: indices[temp_dim] for temp_dim in curr_dims_update}
+                    ref_idx.set(update_dict)
+
+            self.blocked = False
+
+            self._render_indices()
+            self._indices_changed()
+
+
+    @property
+    def blocked(self):
+        return self._blocked
+
+    @blocked.setter
+    def blocked(self, new_state: bool):
+        self._blocked = new_state
+
+
+    def add_synchronized_index(self, ref_index: ReferenceIndex, dim: str):
+        if self is ref_index:
+            return
+
+        if dim not in self.dims or dim not in ref_index.dims:
+            raise ValueError("Both reference indices must have this dimension")
+
+        if ref_index in self._synchronized_indices:
+            self._synchronized_indices[ref_index].add(dim)
+        else:
+            self._synchronized_indices[ref_index] = {dim}
+
+        if self in ref_index._synchronized_indices:
+            ref_index._synchronized_indices[self].add(dim)
+        else:
+            ref_index._synchronized_indices[self] = {dim}
+
+
+    def remove_synchronized_index(self, ref_index: ReferenceIndex, dim: str):
+
+        if ref_index in self._synchronized_indices:
+            self._synchronized_indices[ref_index].discard(dim)
+        else:
+            pass
+
+        if self in ref_index._synchronized_indices:
+            ref_index._synchronized_indices[self].discard(dim)
+        else:
+            pass
+
 
     def _clamp(self, dim, value):
         if isinstance(self.ref_ranges[dim], RangeContinuous):
@@ -212,11 +272,8 @@ class ReferenceIndex:
         return self._indices[dim]
 
     def __setitem__(self, dim, value):
-        self._check_has_dim(dim)
-        # set index for given dim and render
-        self._indices[dim] = self._clamp(dim, value)
-        self._render_indices()
-        self._indices_changed()
+        self.set({dim:value})
+
 
     def _check_has_dim(self, dim):
         if dim not in self.dims:
@@ -304,6 +361,9 @@ class ReferenceIndex:
 
     def __eq__(self, other):
         return self._indices == other
+
+    def __hash__(self):
+        return object.__hash__(self)
 
     def __repr__(self):
         return f"Global Index: {self._indices}"


### PR DESCRIPTION


https://github.com/user-attachments/assets/3e9bd851-04ed-48f2-be91-f6a26254d44d

Goal of this PR is to provide "first-class" support for synchronizing reference index objects. If done right, this will allow visualization systems build with NDWidget to be easily "extended" and "chained together" in arbitrary ways. 

Example problem: you have built/released some visualization code with NDWidget. All widgets so far as synchronized across one scrollable dimension: time. Let's say someone wants to extend this visualization and add a new NDWidget consisting of a single NDImage Graphic. This NDImage graphic has a time dimension (which should be synchronized with the existing NDWidget code). But is also has a "depth" dimension (which was not present in the existing visualization code). Right now, it is nontrivial to link together the old and new code into one coherent system.

It should be possible, without explicitly writing event handlers, to synchronize the time dimensions in this kind of scenario. 

This PR adds functionality to ReferenceIndex to synchronize ReferenceIndex objects. Sample usage would look like: 

```
ref_index_first.add_synchronized_index(ref_index_second, "time")
```
This code synchronizes these two reference index objects across time. An update to the time index of these reference index objects guarantees an equivalent update to the other. 


Here is code that can verify that the implementation does what we'd expect. 
```
data_first = np.random.rand(1000, 20, 20)
data_second = np.random.rand(30, 1000, 20, 20)

ref_range = {"time": (0, 3000, 1)}
ndw_fov_first = fpl.NDWidget(
            ref_range,
            extents=None,
            names=["test1"],
            size=(1200, 1200),
        )

movie_dims = ["time", "m", "n"]
movie_spatial_dims = ["m", "n"]
movie_index_mapping = {"time": np.arange(data_first.shape[0])}
ndw_fov_first['test1'].add_nd_image(data_first,
                     movie_dims,
                     movie_spatial_dims,
                     slider_dim_transforms=movie_index_mapping.copy())


ref_range = {"time": (0, 3000, 1),
            "depth": (0, 30, 1)}
ndw_fov_second = fpl.NDWidget(
            ref_range,
            extents=None,
            names=["test2"],
            size=(1200, 1200),
        )

movie_dims = ["depth", "time", "m", "n"]
movie_spatial_dims = ["m", "n"]
movie_index_mapping = {"time": np.arange(data_second.shape[1]), "depth": np.arange(data_second.shape[0])}
ndw_fov_second['test2'].add_nd_image(data_second,
                     movie_dims,
                     movie_spatial_dims,
                     slider_dim_transforms=movie_index_mapping.copy())


ndw_fov_second.indices.add_synchronized_index(ndw_fov_first.indices, "time")
```

This implementation of ReferenceIndex includes a function, add_synchronized_index which performs symmetric synchronization between self and an input ref_index over a specified dimension. 

The "set" implementation now carefully looks at what was implemented and calls "set" on the other synchronized reference index objects. Note this implementation has event handler style logic to prevent infinite recursion. 