### PR TITLE
Includes code for doing batched transforms in both directions

### DIFF
--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -549,7 +549,7 @@ class Graphic:
         Parameters
         ----------
         position: tuple of (x, y, z) or np.ndarray of shape (num_points, 3)
-            The xyz positions we wish to map to model space
+            The xyz positions we wish to map to world space
 
         Returns
         -------

--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -529,35 +529,28 @@ class Graphic:
         """
 
         if isinstance(position, tuple):
-            if len(position) == 2:
-                # use z of the graphic
-                position = [*position, self.offset[-1]]
+            position = np.array(position)[None, :] #Shape (1, 3)
 
-            if len(position) != 3:
+        if isinstance(position, np.ndarray):
+            if not 0 < position.ndim < 3:
                 raise ValueError(
-                    f"position must be tuple or array indicating (x, y, z) position in *model space*"
+                    f"position can either be shape (num_points, 3) or (3,)"
                 )
-        elif isinstance(position, np.ndarray):
-            if position.ndim > 2:
-                raise ValueError(
-                    f"position can either be shape (num_points, [2, 3]) or ([2, 3],)"
-                )
-            if position.ndim == 1:
+
+            elif position.ndim == 1:
                 position = position[None, :]
 
-            if position.shape[-1] == 2:
-                z_data = np.zeros((position.shape[0], 1))
-                z_data[:] = self.offset[-1]
-                position = np.concatenate(
-                    [position, z_data], axis=1
-                )  # Shape (num_points, 3)
+            if position.shape[-1] != 3:
+                raise ValueError(f"position must have shape (num_points, 3) or (3,), provided shape of {position.shape}")
+
+
             elif position.shape[-1] != 3:
                 raise ValueError(
-                    "position must be a tuple or array indicating (x, y, z). The last dimension should be either 2 or 3"
+                    "position must be a tuple indicating (x, y, z) or an array of shape (num_points, 3)"
                 )
 
         else:
-            raise ValueError("positions must be either a tuple or np.ndarray")
+            raise ValueError("position must be either a tuple or np.ndarray")
 
         return position
 
@@ -569,8 +562,8 @@ class Graphic:
 
         Parameters
         ----------
-        position: (float, float, float) or (float, float) or np.ndarray of shape (num_points, 3), (num_points, 2), (3,), or (2,)
-            The xyz or xy positions we wish to map to model space. If z is not provided then 0 is used
+        position: tuple of (x, y, z) or np.ndarray of shape (num_points, 3)
+            The xyz positions we wish to map to model space
 
         Returns
         -------
@@ -590,8 +583,8 @@ class Graphic:
 
         Parameters
         ----------
-        position: (float, float, float) or (float, float) or np.ndarray of shape (num_points, 3), (num_points, 2), (3,), or (2,)
-            The xyz or xy positions we wish to map to model space. If z is not provided then 0 is used
+        position: tuple of (x, y, z) or np.ndarray of shape (num_points, 3)
+            The xyz positions we wish to map to model space
 
         Returns
         -------

--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -529,10 +529,10 @@ class Graphic:
         """
         position = np.asarray(position)
 
-        if not 0 < position.ndim < 3:
+        if position.ndim not in (1,2):
             raise ValueError(f"position must be of shape (num_points, 3) or (3,)")
 
-        elif position.ndim == 1:
+        if position.ndim == 1:
             position = position[None, :]
 
         if position.shape[-1] != 3:

--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -67,7 +67,6 @@ class Graphic:
     _fpl_support_tooltip: bool = True
 
     def __init_subclass__(cls, **kwargs):
-
         # set of all features
         cls._features = {
             **cls._features,
@@ -326,9 +325,7 @@ class Graphic:
         # used by images since they create new WorldObject ImageTiles when a different buffer size is required
         # also used by GraphicCollections inititally, but not used for reseting like images
         for child in wo.children:
-            if isinstance(
-                    child, (pygfx.Image, pygfx.Volume, pygfx.Points, pygfx.Line)
-            ):
+            if isinstance(child, (pygfx.Image, pygfx.Volume, pygfx.Points, pygfx.Line)):
                 # unique 32 bit integer id for each world object
                 global_id = child.id
                 WORLD_OBJECT_TO_GRAPHIC[global_id] = self
@@ -338,9 +335,7 @@ class Graphic:
     def _remove_group_graphic_map(self, wo: pygfx.Group):
         # remove the children of the group to the WorldObject -> Graphic map
         for child in wo.children:
-            if isinstance(
-                    child, (pygfx.Image, pygfx.Volume, pygfx.Points, pygfx.Line)
-            ):
+            if isinstance(child, (pygfx.Image, pygfx.Volume, pygfx.Points, pygfx.Line)):
                 # unique 32 bit integer id for each world object
                 global_id = child.id
                 WORLD_OBJECT_TO_GRAPHIC.pop(global_id)
@@ -528,6 +523,44 @@ class Graphic:
                 feature = getattr(self, f"_{t}")
                 feature.remove_event_handler(wrapper)
 
+    def _parse_positions(self, position: tuple | np.ndarray) -> np.ndarray:
+        """
+        Converts position data (in the form of tuple or np.ndarray) into a (num_points, 3)-shaped np.ndarray for processing
+        """
+
+        if isinstance(position, tuple):
+            if len(position) == 2:
+                # use z of the graphic
+                position = [*position, self.offset[-1]]
+
+            if len(position) != 3:
+                raise ValueError(
+                    f"position must be tuple or array indicating (x, y, z) position in *model space*"
+                )
+        elif isinstance(position, np.ndarray):
+            if position.ndim > 2:
+                raise ValueError(
+                    f"position can either be shape (num_points, [2, 3]) or ([2, 3],)"
+                )
+            if position.ndim == 1:
+                position = position[None, :]
+
+            if position.shape[-1] == 2:
+                z_data = np.zeros((position.shape[0], 1))
+                z_data[:] = self.offset[-1]
+                position = np.concatenate(
+                    [position, z_data], axis=1
+                )  # Shape (num_points, 3)
+            elif position.shape[-1] != 3:
+                raise ValueError(
+                    "position must be a tuple or array indicating (x, y, z). The last dimension should be either 2 or 3"
+                )
+
+        else:
+            raise ValueError("positions must be either a tuple or np.ndarray")
+
+        return position
+
     def map_model_to_world(
         self, position: tuple[float, float, float] | tuple[float, float] | np.ndarray
     ) -> np.ndarray:
@@ -536,27 +569,18 @@ class Graphic:
 
         Parameters
         ----------
-        position: (float, float, float) or (float, float)
-            (x, y, z) or (x, y) position. If z is not provided then the graphic's offset z is used.
+        position: (float, float, float) or (float, float) or np.ndarray of shape (num_points, 3), (num_points, 2), (3,), or (2,)
+            The xyz or xy positions we wish to map to model space. If z is not provided then 0 is used
 
         Returns
         -------
         np.ndarray
-            (x, y, z) position in world space
-
+            either shape (3,) or (num_points, 3), specifying position in world space
         """
-
-        if len(position) == 2:
-            # use z of the graphic
-            position = [*position, self.offset[-1]]
-
-        if len(position) != 3:
-            raise ValueError(
-                f"position must be tuple or array indicating (x, y, z) position in *model space*"
-            )
+        position = self._parse_positions(position)
 
         # apply world transform to project from model space to world space
-        return la.vec_transform(position, self.world_object.world.matrix)
+        return la.vec_transform(position, self.world_object.world.matrix).squeeze()
 
     def map_world_to_model(
         self, position: tuple[float, float, float] | tuple[float, float] | np.ndarray
@@ -566,26 +590,20 @@ class Graphic:
 
         Parameters
         ----------
-        position: (float, float, float) or (float, float)
-            (x, y, z) or (x, y) position. If z is not provided then 0 is used.
+        position: (float, float, float) or (float, float) or np.ndarray of shape (num_points, 3), (num_points, 2), (3,), or (2,)
+            The xyz or xy positions we wish to map to model space. If z is not provided then 0 is used
 
         Returns
         -------
         np.ndarray
-            (x, y, z) position in world space
+            either shape (3,) or (num_points, 3), specifying position in model space
 
         """
+        position = self._parse_positions(position)
 
-        if len(position) == 2:
-            # use z of the graphic
-            position = [*position, self.offset[-1]]
-
-        if len(position) != 3:
-            raise ValueError(
-                f"position must be tuple or array indicating (x, y, z) position in *model space*"
-            )
-
-        return la.vec_transform(position, self.world_object.world.inverse_matrix)
+        return la.vec_transform(
+            position, self.world_object.world.inverse_matrix
+        ).squeeze()
 
     def format_pick_info(self, ev: pygfx.PointerEvent) -> str:
         """

--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -527,15 +527,10 @@ class Graphic:
         """
         Converts position data (in the form of tuple or np.ndarray) into a (num_points, 3)-shaped np.ndarray for processing
         """
-        if not isinstance(position, (np.ndarray, tuple)):
-            raise ValueError("position must be either a tuple or np.ndarray")
-
-        position = np.array(position)
+        position = np.asarray(position)
 
         if not 0 < position.ndim < 3:
-            raise ValueError(
-                f"position must be of shape (num_points, 3) or (3,)"
-            )
+            raise ValueError(f"position must be of shape (num_points, 3) or (3,)")
 
         elif position.ndim == 1:
             position = position[None, :]

--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -527,30 +527,21 @@ class Graphic:
         """
         Converts position data (in the form of tuple or np.ndarray) into a (num_points, 3)-shaped np.ndarray for processing
         """
-
-        if isinstance(position, tuple):
-            position = np.array(position)[None, :] #Shape (1, 3)
-
-        if isinstance(position, np.ndarray):
-            if not 0 < position.ndim < 3:
-                raise ValueError(
-                    f"position must be of shape (num_points, 3) or (3,)"
-                )
-
-            elif position.ndim == 1:
-                position = position[None, :]
-
-            if position.shape[-1] != 3:
-                raise ValueError(f"position must be of shape (num_points, 3) or (3,)")
-
-
-            elif position.shape[-1] != 3:
-                raise ValueError(
-                    "position must be of shape (num_points, 3) or (3,)"
-                )
-
-        else:
+        if not isinstance(position, (np.ndarray, tuple)):
             raise ValueError("position must be either a tuple or np.ndarray")
+
+        position = np.array(position)
+
+        if not 0 < position.ndim < 3:
+            raise ValueError(
+                f"position must be of shape (num_points, 3) or (3,)"
+            )
+
+        elif position.ndim == 1:
+            position = position[None, :]
+
+        if position.shape[-1] != 3:
+            raise ValueError(f"position must be of shape (num_points, 3) or (3,)")
 
         return position
 

--- a/fastplotlib/graphics/_base.py
+++ b/fastplotlib/graphics/_base.py
@@ -534,19 +534,19 @@ class Graphic:
         if isinstance(position, np.ndarray):
             if not 0 < position.ndim < 3:
                 raise ValueError(
-                    f"position can either be shape (num_points, 3) or (3,)"
+                    f"position must be of shape (num_points, 3) or (3,)"
                 )
 
             elif position.ndim == 1:
                 position = position[None, :]
 
             if position.shape[-1] != 3:
-                raise ValueError(f"position must have shape (num_points, 3) or (3,), provided shape of {position.shape}")
+                raise ValueError(f"position must be of shape (num_points, 3) or (3,)")
 
 
             elif position.shape[-1] != 3:
                 raise ValueError(
-                    "position must be a tuple indicating (x, y, z) or an array of shape (num_points, 3)"
+                    "position must be of shape (num_points, 3) or (3,)"
                 )
 
         else:


### PR DESCRIPTION
This PR allows you to do batched coordinate transforms. You have a graphic, the graphic has data points stored in model space. You want to transform all of those model points to world space (or go from world space to model space). Easy to batch/vectorize this via pylinalg but the fpl functions didn't allow for this. 

You can do this now: 

```
my_data = graphic.data[:] # Let's say this is shape (100, 3)
world_coords = graphic.map_model_to_world(my_data) 
```

graphic.map_world_to_model also supports this now