### PR TITLE
drop python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
     "vulkan",
     "gpu",
 ]
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 dependencies = [
     "numpy>=1.23.0",
     "pygfx==0.15.3",


### PR DESCRIPTION
wgpu-py is dropping it and EOL is soon anyways: https://github.com/pygfx/wgpu-py/pull/813

I've been recommending min python 3.11 for years now anyways

@clewis7 gtg!
