### PR TITLE
Includes basic np dlpack function that is tested to work across jax a…

### DIFF
--- a/fastplotlib/utils/functions.py
+++ b/fastplotlib/utils/functions.py
@@ -409,7 +409,7 @@ def parse_cmap_values(
 
 def cuda_to_numpy(arr: CudaArrayProtocol) -> np.ndarray:
 
-    data = np.from_dlpack(arr, device='cpu') #This requires numpy >= 2.1
+    data = np.from_dlpack(arr, device='cpu')
     return data
 
 

--- a/fastplotlib/utils/functions.py
+++ b/fastplotlib/utils/functions.py
@@ -408,14 +408,10 @@ def parse_cmap_values(
 
 
 def cuda_to_numpy(arr: CudaArrayProtocol) -> np.ndarray:
-    try:
-        import cupy
-    except ImportError:
-        raise ImportError(
-            "`cupy` is required to work with GPU arrays\npip install cupy"
-        )
 
-    return cupy.asnumpy(arr)
+    data = np.from_dlpack(arr, device='cpu') #This requires numpy >= 2.1
+    return data
+
 
 
 def subsample_array(

--- a/fastplotlib/utils/functions.py
+++ b/fastplotlib/utils/functions.py
@@ -413,7 +413,6 @@ def cuda_to_numpy(arr: CudaArrayProtocol) -> np.ndarray:
     return data
 
 
-
 def subsample_array(
     arr: CudaArrayProtocol,
     max_size: int = 1e6,

--- a/fastplotlib/widgets/nd_widget/_base.py
+++ b/fastplotlib/widgets/nd_widget/_base.py
@@ -198,18 +198,12 @@ class NDProcessor:
 
         self._spatial_dims = tuple(sdims)
 
-        ## This is the ordered sequence of data indices that will be displayed
-        self._spatial_dims_indices = tuple(
-            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
-        )
-
     @property
     def spatial_dims_indices(self) -> tuple[int, ...]:
         """
-        The ordered sequence of data indices that will be displayed
+        The ordered spatial dim indices that correspond to the named spatial dims
         """
-        return self._spatial_dims_indices
-
+        return tuple(self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims)
 
     @property
     def tooltip(self) -> bool:

--- a/fastplotlib/widgets/nd_widget/_base.py
+++ b/fastplotlib/widgets/nd_widget/_base.py
@@ -198,6 +198,19 @@ class NDProcessor:
 
         self._spatial_dims = tuple(sdims)
 
+        ## This is the ordered sequence of data indices that will be displayed
+        self._spatial_dims_indices = tuple(
+            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
+        )
+
+    @property
+    def spatial_dims_indices(self) -> tuple[int, ...]:
+        """
+        The ordered sequence of data indices that will be displayed
+        """
+        return self._spatial_dims_indices
+
+
     @property
     def tooltip(self) -> bool:
         """

--- a/fastplotlib/widgets/nd_widget/_base.py
+++ b/fastplotlib/widgets/nd_widget/_base.py
@@ -529,12 +529,7 @@ class NDProcessor:
                 f"windowed_slice.ndim != len(self.spatial_dims): {windowed_slice.ndim} != {len(self.spatial_dims)}"
             )
 
-        # transpose to spatial dims
-        spatial_dims_int = tuple(
-            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
-        )
-
-        return windowed_slice.transpose(*spatial_dims_int)
+        return windowed_slice
 
     async def _get_raw_data_slice(self, indices: dict[str, Any]) -> ArrayProtocol:
         """

--- a/fastplotlib/widgets/nd_widget/_nd_image.py
+++ b/fastplotlib/widgets/nd_widget/_nd_image.py
@@ -137,6 +137,11 @@ class NDImageProcessor(NDProcessor):
         self._compute_histogram = compute_histogram
         self._recompute_histogram()
 
+        # Axis order of the spatial dimensions to display
+        self._spatial_dims_int = tuple(
+            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
+        )
+
     @property
     def data(self) -> ArrayProtocol | None:
         """
@@ -258,7 +263,8 @@ class NDImageProcessor(NDProcessor):
         if isinstance(window_output, CudaArrayProtocol):
             window_output = await run_in_thread_pool(self._executor, cuda_to_numpy, window_output)
 
-        return window_output
+
+        return window_output.transpose(*self._spatial_dims_int)
 
     def _recompute_histogram(self):
         """

--- a/fastplotlib/widgets/nd_widget/_nd_image.py
+++ b/fastplotlib/widgets/nd_widget/_nd_image.py
@@ -186,18 +186,6 @@ class NDImageProcessor(NDProcessor):
 
         self._spatial_dims = tuple(sdims)
 
-        ## This is the ordered sequence of data indices that will be displayed
-        self._spatial_dims_indices = tuple(
-            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
-        )
-
-    @property
-    def spatial_dims_indices(self) -> tuple[int, ...]:
-        """
-        The ordered sequence of data indices that will be displayed
-        """
-        return self._spatial_dims_indices
-
     @property
     def rgb_dim(self) -> str | None:
         """
@@ -269,7 +257,6 @@ class NDImageProcessor(NDProcessor):
         # final CUDA -> numpy conversion at the end of the pipeline
         if isinstance(window_output, CudaArrayProtocol):
             window_output = await run_in_thread_pool(self._executor, cuda_to_numpy, window_output)
-
 
         return window_output.transpose(*self.spatial_dims_indices)
 

--- a/fastplotlib/widgets/nd_widget/_nd_image.py
+++ b/fastplotlib/widgets/nd_widget/_nd_image.py
@@ -137,11 +137,6 @@ class NDImageProcessor(NDProcessor):
         self._compute_histogram = compute_histogram
         self._recompute_histogram()
 
-        # Axis order of the spatial dimensions to display
-        self._spatial_dims_int = tuple(
-            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
-        )
-
     @property
     def data(self) -> ArrayProtocol | None:
         """
@@ -190,6 +185,18 @@ class NDImageProcessor(NDProcessor):
             )
 
         self._spatial_dims = tuple(sdims)
+
+        ## This is the ordered sequence of data indices that will be displayed
+        self._spatial_dims_indices = tuple(
+            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
+        )
+
+    @property
+    def spatial_dims_indices(self) -> tuple[int, ...]:
+        """
+        The ordered sequence of data indices that will be displayed
+        """
+        return self._spatial_dims_indices
 
     @property
     def rgb_dim(self) -> str | None:
@@ -264,7 +271,7 @@ class NDImageProcessor(NDProcessor):
             window_output = await run_in_thread_pool(self._executor, cuda_to_numpy, window_output)
 
 
-        return window_output.transpose(*self._spatial_dims_int)
+        return window_output.transpose(*self.spatial_dims_indices)
 
     def _recompute_histogram(self):
         """

--- a/fastplotlib/widgets/nd_widget/_nd_positions/_nd_positions.py
+++ b/fastplotlib/widgets/nd_widget/_nd_positions/_nd_positions.py
@@ -112,6 +112,11 @@ class NDPositionsProcessor(NDProcessor):
         self.cmap_transform_each = cmap_transform_each
         self.sizes = sizes
 
+        # Axis order of the spatial dimensions to display
+        self._spatial_dims_int = tuple(
+            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
+        )
+
     def _check_shape_feature(
         self, prop: str, check_shape: tuple[int, int]
     ) -> tuple[int, int]:
@@ -554,6 +559,8 @@ class NDPositionsProcessor(NDProcessor):
         # final CUDA -> numpy conversion at the end of the pipeline
         if isinstance(data, CudaArrayProtocol):
             data = await run_in_thread_pool(self._executor, cuda_to_numpy, data)
+
+        data = data.transpose(*self._spatial_dims_int)
 
         return {
             "data": data,

--- a/fastplotlib/widgets/nd_widget/_nd_positions/_nd_positions.py
+++ b/fastplotlib/widgets/nd_widget/_nd_positions/_nd_positions.py
@@ -112,10 +112,6 @@ class NDPositionsProcessor(NDProcessor):
         self.cmap_transform_each = cmap_transform_each
         self.sizes = sizes
 
-        # Axis order of the spatial dimensions to display
-        self._spatial_dims_int = tuple(
-            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
-        )
 
     def _check_shape_feature(
         self, prop: str, check_shape: tuple[int, int]
@@ -302,6 +298,18 @@ class NDPositionsProcessor(NDProcessor):
             raise KeyError
 
         self._spatial_dims = tuple(sdims)
+
+        ## This is the ordered sequence of data indices that will be displayed
+        self._spatial_dims_indices = tuple(
+            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
+        )
+
+    @property
+    def spatial_dims_indices(self) -> tuple[int, ...]:
+        """
+        The ordered sequence of data indices that will be displayed
+        """
+        return self._spatial_dims_indices
 
     @property
     def slider_dims(self) -> set[Hashable]:

--- a/fastplotlib/widgets/nd_widget/_nd_positions/_nd_positions.py
+++ b/fastplotlib/widgets/nd_widget/_nd_positions/_nd_positions.py
@@ -299,18 +299,6 @@ class NDPositionsProcessor(NDProcessor):
 
         self._spatial_dims = tuple(sdims)
 
-        ## This is the ordered sequence of data indices that will be displayed
-        self._spatial_dims_indices = tuple(
-            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
-        )
-
-    @property
-    def spatial_dims_indices(self) -> tuple[int, ...]:
-        """
-        The ordered sequence of data indices that will be displayed
-        """
-        return self._spatial_dims_indices
-
     @property
     def slider_dims(self) -> set[Hashable]:
         # append `p` dim to slider dims
@@ -568,7 +556,7 @@ class NDPositionsProcessor(NDProcessor):
         if isinstance(data, CudaArrayProtocol):
             data = await run_in_thread_pool(self._executor, cuda_to_numpy, data)
 
-        data = data.transpose(*self._spatial_dims_int)
+        data = data.transpose(*self.spatial_dims_indices)
 
         return {
             "data": data,

--- a/fastplotlib/widgets/nd_widget/_nd_vectors.py
+++ b/fastplotlib/widgets/nd_widget/_nd_vectors.py
@@ -91,6 +91,12 @@ class NDVectorsProcessor(NDProcessor):
             spatial_func=spatial_func,
         )
 
+        # Axis order of the spatial dimensions to display
+        self._spatial_dims_int = tuple(
+            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
+        )
+
+
     @property
     def data(self) -> ArrayProtocol | None:
         """
@@ -157,7 +163,7 @@ class NDVectorsProcessor(NDProcessor):
             Example: get((100, 5))
 
         """
-        # this will be squeezed output, with dims in the order of the user set spatial dims
+        # this will be squeezed output, with dims in the order of self.dims
         window_output = await self.get_window_output(indices)
 
         # apply spatial_func; CUDA arrays run inline, numpy goes through the thread pool
@@ -175,7 +181,8 @@ class NDVectorsProcessor(NDProcessor):
         if isinstance(window_output, CudaArrayProtocol):
             window_output = await run_in_thread_pool(self._executor, cuda_to_numpy, window_output)
 
-        return window_output
+
+        return window_output.transpose(*self._spatial_dims_int)
 
 
 class NDVectors(NDGraphic):

--- a/fastplotlib/widgets/nd_widget/_nd_vectors.py
+++ b/fastplotlib/widgets/nd_widget/_nd_vectors.py
@@ -91,12 +91,6 @@ class NDVectorsProcessor(NDProcessor):
             spatial_func=spatial_func,
         )
 
-        # Axis order of the spatial dimensions to display
-        self._spatial_dims_int = tuple(
-            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
-        )
-
-
     @property
     def data(self) -> ArrayProtocol | None:
         """
@@ -149,6 +143,18 @@ class NDVectorsProcessor(NDProcessor):
                 f"Spatial dimensions must haves shape (num_vecs, 2, [2 or 3]) you passed {sdims}"
             )
 
+        ## This is the ordered sequence of data indices that will be displayed
+        self._spatial_dims_indices = tuple(
+            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
+        )
+
+    @property
+    def spatial_dims_indices(self) -> tuple[int, ...]:
+        """
+        The ordered sequence of data indices that will be displayed
+        """
+        return self._spatial_dims_indices
+
     async def get(self, indices: dict[str, Any]) -> ArrayProtocol:
         """
         Get the data at the given index, process data through the window functions.
@@ -182,7 +188,7 @@ class NDVectorsProcessor(NDProcessor):
             window_output = await run_in_thread_pool(self._executor, cuda_to_numpy, window_output)
 
 
-        return window_output.transpose(*self._spatial_dims_int)
+        return window_output.transpose(*self._spatial_dims_indices)
 
 
 class NDVectors(NDGraphic):

--- a/fastplotlib/widgets/nd_widget/_nd_vectors.py
+++ b/fastplotlib/widgets/nd_widget/_nd_vectors.py
@@ -143,18 +143,6 @@ class NDVectorsProcessor(NDProcessor):
                 f"Spatial dimensions must haves shape (num_vecs, 2, [2 or 3]) you passed {sdims}"
             )
 
-        ## This is the ordered sequence of data indices that will be displayed
-        self._spatial_dims_indices = tuple(
-            self.spatial_dims.index(d) for d in self.dims if d in self.spatial_dims
-        )
-
-    @property
-    def spatial_dims_indices(self) -> tuple[int, ...]:
-        """
-        The ordered sequence of data indices that will be displayed
-        """
-        return self._spatial_dims_indices
-
     async def get(self, indices: dict[str, Any]) -> ArrayProtocol:
         """
         Get the data at the given index, process data through the window functions.
@@ -187,8 +175,7 @@ class NDVectorsProcessor(NDProcessor):
         if isinstance(window_output, CudaArrayProtocol):
             window_output = await run_in_thread_pool(self._executor, cuda_to_numpy, window_output)
 
-
-        return window_output.transpose(*self._spatial_dims_indices)
+        return window_output.transpose(*self.spatial_dims_indices)
 
 
 class NDVectors(NDGraphic):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
-    "numpy>=1.23.0",
+    "numpy>=2.1.0",
     "pygfx==0.16.0",
     "wgpu",          # Let pygfx constrain the wgpu version
     "cmap>=0.1.3",


### PR DESCRIPTION
Fixes #1063

The numpy dlpack fully sidesteps the need to rely on torch, but it requires numpy > 2.1. I think this is ok, since numpy is now at 2.5, and only users who care about high-performance (i.e. computing on GPUs) will use this execution path anyways. 