### PR TITLE
Use namespaced "matplotlib:coolwarm" to silence cmap ambiguity warning

### DIFF
--- a/fastplotlib/utils/functions.py
+++ b/fastplotlib/utils/functions.py
@@ -59,7 +59,7 @@ COLORMAPS = sorted(
         "RdYlBu",
         "RdYlGn",
         "Spectral",
-        "coolwarm",
+        "matplotlib:coolwarm",
         "bwr",
         "seismic",
         "berlin",


### PR DESCRIPTION
Hey @kushalkolar hopefully this one liner is ok with you!

This avoids a warning like:

```
WARNING: The name 'coolwarm' is an alias for 'matplotlib:coolwarm', but is also available as: 'paraview:coolwarm'.
To silence this warning, use a fully namespaced name.
```

~This PR was written by Mark's AI agent (Claude Code). Mark has not yet reviewed this PR.~

Reviewed it now!

<details><summary>More stuff from claude</summary>

## Summary
- `"coolwarm"` is ambiguous in the `cmap` package's catalog (present in both the `matplotlib` and `paraview` namespaces), so `cmap.Colormap("coolwarm")` emits the ambiguity warning above.
- Use the fully namespaced `"matplotlib:coolwarm"` in `COLORMAPS`, matching the pattern already used for other ambiguous names in that list (`tol:`, `matlab:`, `vispy:`, `gnuplot:`, `yorick:`).
- This namespace syntax is supported by `cmap>=0.1.3`, which is already fastplotlib's declared minimum dependency, so no dependency bump is needed.

## Test plan
- [x] Confirmed the warning no longer fires when importing `fastplotlib.utils.functions` after the change.
- [x] Confirmed `"coolwarm"` was not referenced as a literal string anywhere else in the codebase.

https://claude.ai/code/session_01XccZFAE1DAEaEx7LBhXE5W

</details>